### PR TITLE
Add compute_place_orientation and get_graspable_grocery_objects_from_…

### DIFF
--- a/src/compute_place_orientation/CMakeLists.txt
+++ b/src/compute_place_orientation/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.22)
+project(compute_place_orientation CXX)
+
+find_package(moveit_pro_package REQUIRED)
+moveit_pro_package()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  geometry_msgs
+  moveit_pro_behavior_interface
+  pluginlib
+  tf2_eigen
+)
+foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${package} REQUIRED)
+endforeach()
+
+find_package(spdlog REQUIRED)
+
+add_library(compute_place_orientation SHARED
+  src/compute_place_orientation.cpp
+  src/register_behaviors.cpp
+)
+target_include_directories(compute_place_orientation
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(compute_place_orientation ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(compute_place_orientation spdlog::spdlog)
+
+install(
+  TARGETS compute_place_orientation
+  EXPORT compute_place_orientationTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
+pluginlib_export_plugin_description_file(
+  moveit_pro_behavior_interface compute_place_orientation_plugin_description.xml)
+
+ament_export_targets(compute_place_orientationTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/compute_place_orientation/compute_place_orientation_plugin_description.xml
+++ b/src/compute_place_orientation/compute_place_orientation_plugin_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<library path="compute_place_orientation">
+  <class
+    type="compute_place_orientation::ComputePlaceOrientationBehaviorsLoader"
+    base_class_type="moveit_pro::behaviors::SharedResourcesNodeLoaderBase"
+  />
+</library>

--- a/src/compute_place_orientation/include/compute_place_orientation/compute_place_orientation.hpp
+++ b/src/compute_place_orientation/include/compute_place_orientation/compute_place_orientation.hpp
@@ -1,0 +1,46 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+
+namespace compute_place_orientation
+{
+
+/**
+ * @brief Computes the grasp_link pose for placing an object upright at a target position.
+ *
+ * @details Given the object's pose at detection time, the grasp_link pose at pick time,
+ * and a target place position, this behavior computes the grasp_link orientation needed
+ * so that the object's longest axis (Z axis of the fitted shape frame) is vertical
+ * when placed.
+ *
+ * The math:
+ *   T_grasp_object = T_world_grasp^-1 * T_world_object  (fixed after grasping)
+ *   R_world_object_desired = rotation that aligns object Z with world Z
+ *   T_world_grasp_desired = T_world_object_desired * T_grasp_object^-1
+ *
+ * | Data Port Name     | Port Type | Object Type                          |
+ * | ------------------ | --------- | ------------------------------------ |
+ * | object_pose        | input     | geometry_msgs::msg::PoseStamped      |
+ * | pick_pose          | input     | geometry_msgs::msg::PoseStamped      |
+ * | place_position     | input     | geometry_msgs::msg::PoseStamped      |
+ * | place_pose         | output    | geometry_msgs::msg::PoseStamped      |
+ */
+class ComputePlaceOrientation final : public BT::SyncActionNode
+{
+public:
+  ComputePlaceOrientation(const std::string& name, const BT::NodeConfiguration& config);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+
+}  // namespace compute_place_orientation

--- a/src/compute_place_orientation/package.xml
+++ b/src/compute_place_orientation/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<package format="3">
+  <name>compute_place_orientation</name>
+  <version>0.0.1</version>
+  <description>
+    Computes the grasp_link orientation for placing an object upright at a target location.
+  </description>
+  <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_pro_package</build_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>moveit_pro_behavior_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>tf2_eigen</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/compute_place_orientation/src/compute_place_orientation.cpp
+++ b/src/compute_place_orientation/src/compute_place_orientation.cpp
@@ -1,0 +1,153 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <compute_place_orientation/compute_place_orientation.hpp>
+
+#include <Eigen/Dense>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <spdlog/spdlog.h>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+namespace
+{
+constexpr auto kPortIDObjectPose = "object_pose";
+constexpr auto kPortIDPickPose = "pick_pose";
+constexpr auto kPortIDPlacePosition = "place_position";
+constexpr auto kPortIDPlacePose = "place_pose";
+constexpr auto kPortIDHeightOffset = "height_offset";
+
+/**
+ * @brief Convert a PoseStamped to an Eigen::Isometry3d.
+ */
+Eigen::Isometry3d poseToIsometry(const geometry_msgs::msg::PoseStamped& pose_msg)
+{
+  Eigen::Isometry3d iso = Eigen::Isometry3d::Identity();
+  iso.translation() = Eigen::Vector3d(pose_msg.pose.position.x, pose_msg.pose.position.y, pose_msg.pose.position.z);
+  Eigen::Quaterniond q(pose_msg.pose.orientation.w, pose_msg.pose.orientation.x, pose_msg.pose.orientation.y,
+                       pose_msg.pose.orientation.z);
+  iso.linear() = q.toRotationMatrix();
+  return iso;
+}
+
+}  // namespace
+
+namespace compute_place_orientation
+{
+
+ComputePlaceOrientation::ComputePlaceOrientation(const std::string& name, const BT::NodeConfiguration& config)
+  : BT::SyncActionNode(name, config)
+{
+}
+
+BT::PortsList ComputePlaceOrientation::providedPorts()
+{
+  return {
+    BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDObjectPose, "{object_pose}",
+                                                    "Object pose in world frame from detection."),
+    BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDPickPose, "{pick_pose}",
+                                                    "Grasp_link pose in world frame at the time of picking."),
+    BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDPlacePosition, "{shelf_target_pose}",
+                                                    "Target place position (only XY used, Z computed from height_offset)."),
+    BT::InputPort<double>(kPortIDHeightOffset, 0.0,
+                          "Height offset above the place position for the object bottom (typically place_height)."),
+    BT::OutputPort<geometry_msgs::msg::PoseStamped>(kPortIDPlacePose, "{place_pose}",
+                                                     "Computed grasp_link pose for placing the object upright."),
+  };
+}
+
+BT::KeyValueVector ComputePlaceOrientation::metadata()
+{
+  return { { "subcategory", "Motion - Planning" },
+           { "description",
+             "Computes the grasp_link pose for placing a held object upright at a target location. "
+             "The object's longest axis (Z of its fitted shape frame) is aligned with world Z." } };
+}
+
+BT::NodeStatus ComputePlaceOrientation::tick()
+{
+  const auto object_pose_input = getInput<geometry_msgs::msg::PoseStamped>(kPortIDObjectPose);
+  const auto pick_pose_input = getInput<geometry_msgs::msg::PoseStamped>(kPortIDPickPose);
+  const auto place_position_input = getInput<geometry_msgs::msg::PoseStamped>(kPortIDPlacePosition);
+  const auto height_offset_input = getInput<double>(kPortIDHeightOffset);
+
+  if (!object_pose_input || !pick_pose_input || !place_position_input)
+  {
+    spdlog::error("ComputePlaceOrientation: failed to get required input ports.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const double height_offset = height_offset_input.value_or(0.0);
+
+  // T_world_object: object's pose in world frame at detection time
+  const Eigen::Isometry3d T_world_object = poseToIsometry(object_pose_input.value());
+  // T_world_grasp: grasp_link's pose in world frame at pick time
+  const Eigen::Isometry3d T_world_grasp = poseToIsometry(pick_pose_input.value());
+
+  // Compute the fixed transform from grasp_link to object (doesn't change after grasping)
+  const Eigen::Isometry3d T_grasp_object = T_world_grasp.inverse() * T_world_object;
+
+  spdlog::info("ComputePlaceOrientation: T_grasp_object translation = [{:.4f}, {:.4f}, {:.4f}]",
+               T_grasp_object.translation().x(), T_grasp_object.translation().y(),
+               T_grasp_object.translation().z());
+
+  // Desired object orientation at place: object Z aligned with world Z.
+  // We want the object's Z axis (longest axis of fitted shape) to point up.
+  // The simplest: R_world_object_desired = Identity (object Z = world Z).
+  // But we also need to choose a yaw. Use the object's original yaw (around Z).
+  const Eigen::Vector3d object_z = T_world_object.linear().col(2);
+  spdlog::info("ComputePlaceOrientation: object Z axis in world = [{:.4f}, {:.4f}, {:.4f}]",
+               object_z.x(), object_z.y(), object_z.z());
+
+  // For the desired orientation, we want object Z = world Z.
+  // Preserve the object's XY orientation (yaw) as much as possible.
+  Eigen::Isometry3d T_world_object_desired = Eigen::Isometry3d::Identity();
+
+  // Place position from input. The object center when upright is at shelf_z + half of height_offset.
+  // height_offset is the full object height (longest axis), so center = shelf_z + height_offset/2.
+  const auto& place_pos = place_position_input.value();
+  T_world_object_desired.translation() =
+      Eigen::Vector3d(place_pos.pose.position.x, place_pos.pose.position.y,
+                      place_pos.pose.position.z + height_offset / 2.0);
+  spdlog::info("ComputePlaceOrientation: object center at z={:.4f} (shelf_z={:.4f} + height/2={:.4f})",
+               T_world_object_desired.translation().z(), place_pos.pose.position.z, height_offset / 2.0);
+
+  // Desired object rotation: Z = world Z, preserve original yaw
+  // Project the object's X axis onto the XY plane for yaw preservation
+  Eigen::Vector3d object_x = T_world_object.linear().col(0);
+  object_x.z() = 0.0;
+  if (object_x.norm() < 1e-6)
+  {
+    // Object X is nearly vertical, use world X instead
+    object_x = Eigen::Vector3d::UnitX();
+  }
+  object_x.normalize();
+  const Eigen::Vector3d desired_z = Eigen::Vector3d::UnitZ();
+  const Eigen::Vector3d desired_y = desired_z.cross(object_x).normalized();
+  const Eigen::Vector3d desired_x = desired_y.cross(desired_z).normalized();
+
+  Eigen::Matrix3d R_desired;
+  R_desired.col(0) = desired_x;
+  R_desired.col(1) = desired_y;
+  R_desired.col(2) = desired_z;
+  T_world_object_desired.linear() = R_desired;
+
+  // Compute the desired grasp_link pose: T_world_grasp_desired = T_world_object_desired * T_grasp_object^-1
+  const Eigen::Isometry3d T_world_grasp_desired = T_world_object_desired * T_grasp_object.inverse();
+
+  spdlog::info("ComputePlaceOrientation: desired grasp position = [{:.4f}, {:.4f}, {:.4f}]",
+               T_world_grasp_desired.translation().x(), T_world_grasp_desired.translation().y(),
+               T_world_grasp_desired.translation().z());
+
+  // Convert to PoseStamped
+  geometry_msgs::msg::PoseStamped place_pose;
+  place_pose.header.frame_id = object_pose_input->header.frame_id;
+  place_pose.pose = tf2::toMsg(T_world_grasp_desired);
+
+  setOutput(kPortIDPlacePose, place_pose);
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace compute_place_orientation

--- a/src/compute_place_orientation/src/register_behaviors.cpp
+++ b/src/compute_place_orientation/src/register_behaviors.cpp
@@ -1,0 +1,29 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <compute_place_orientation/compute_place_orientation.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace compute_place_orientation
+{
+class ComputePlaceOrientationBehaviorsLoader : public moveit_pro::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(BT::BehaviorTreeFactory& factory,
+    [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_pro::behaviors::registerBehavior<ComputePlaceOrientation>(factory, "ComputePlaceOrientation");
+  }
+};
+}  // namespace compute_place_orientation
+
+PLUGINLIB_EXPORT_CLASS(compute_place_orientation::ComputePlaceOrientationBehaviorsLoader,
+                       moveit_pro::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/compute_place_orientation/test/CMakeLists.txt
+++ b/src/compute_place_orientation/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+# No tests yet

--- a/src/get_graspable_grocery_objects_from_masks3d/CMakeLists.txt
+++ b/src/get_graspable_grocery_objects_from_masks3d/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.22)
+project(get_graspable_grocery_objects_from_masks3d CXX)
+
+find_package(moveit_pro_package REQUIRED)
+moveit_pro_package()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  moveit_pro_behavior_interface
+  moveit_studio_vision_msgs
+  pcl_conversions
+  pcl_ros
+  sensor_msgs
+  shape_msgs
+  tf2_eigen
+  tf2_ros
+  visualization_msgs
+  pluginlib
+)
+foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${package} REQUIRED)
+endforeach()
+
+find_package(PCL REQUIRED COMPONENTS common segmentation search features)
+find_package(spdlog REQUIRED)
+
+add_library(
+  get_graspable_grocery_objects_from_masks3d
+  SHARED
+  src/shape_fitting.cpp
+  src/compute_grocery_place_height.cpp
+  src/get_graspable_grocery_objects_from_masks3d.cpp
+  src/register_behaviors.cpp)
+target_include_directories(
+  get_graspable_grocery_objects_from_masks3d
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(get_graspable_grocery_objects_from_masks3d
+                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(get_graspable_grocery_objects_from_masks3d
+  ${PCL_LIBRARIES}
+  spdlog::spdlog)
+target_include_directories(get_graspable_grocery_objects_from_masks3d
+  PRIVATE ${PCL_INCLUDE_DIRS})
+
+# Install Libraries
+install(
+  TARGETS get_graspable_grocery_objects_from_masks3d
+  EXPORT get_graspable_grocery_objects_from_masks3dTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES
+  DESTINATION include)
+
+if(BUILD_TESTING)
+  moveit_pro_behavior_test(get_graspable_grocery_objects_from_masks3d)
+endif()
+
+# Export the behavior plugins defined in this package so they are available to
+# plugin loaders that load the behavior base class library from the
+# moveit_pro_behavior package.
+pluginlib_export_plugin_description_file(
+  moveit_pro_behavior_interface get_graspable_grocery_objects_from_masks3d_plugin_description.xml)
+
+ament_export_targets(get_graspable_grocery_objects_from_masks3dTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/get_graspable_grocery_objects_from_masks3d/get_graspable_grocery_objects_from_masks3d_plugin_description.xml
+++ b/src/get_graspable_grocery_objects_from_masks3d/get_graspable_grocery_objects_from_masks3d_plugin_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<library path="get_graspable_grocery_objects_from_masks3d">
+  <class
+    type="get_graspable_grocery_objects_from_masks3d::GetGraspableGroceryObjectsFromMasks3DBehaviorsLoader"
+    base_class_type="moveit_pro::behaviors::SharedResourcesNodeLoaderBase"
+  />
+</library>

--- a/src/get_graspable_grocery_objects_from_masks3d/include/get_graspable_grocery_objects_from_masks3d/compute_grocery_place_height.hpp
+++ b/src/get_graspable_grocery_objects_from_masks3d/include/get_graspable_grocery_objects_from_masks3d/compute_grocery_place_height.hpp
@@ -1,0 +1,47 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+#include <moveit_studio_vision_msgs/msg/graspable_object.hpp>
+
+namespace get_graspable_grocery_objects_from_masks3d
+{
+
+/**
+ * @brief Computes the place height for a grocery item based on its fitted shape and grasp convention.
+ *
+ * @details Given a GraspableObject with a fitted shape type stored in grasp_info.object_type, this
+ * behavior computes the height at which grasp_link should be positioned above the shelf target so
+ * that the object rests on the shelf with its longest axis perpendicular to the surface.
+ *
+ * Grasp conventions:
+ * - Box: grasped at the center of a face. Place height = half the longest box dimension.
+ * - Cylinder: grasped on the top flat face. Place height = full cylinder height.
+ * - Sphere: grasped anywhere. Place height = full diameter (2 * radius).
+ *
+ * | Data Port Name    | Port Type | Object Type                                         |
+ * | ----------------- | --------- | --------------------------------------------------- |
+ * | graspable_object  | input     | moveit_studio_vision_msgs::msg::GraspableObject     |
+ * | place_height      | output    | double                                              |
+ * | shape_type        | output    | std::string                                         |
+ */
+class ComputeGroceryPlaceHeight final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  ComputeGroceryPlaceHeight(const std::string& name, const BT::NodeConfiguration& config,
+                            const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+
+}  // namespace get_graspable_grocery_objects_from_masks3d

--- a/src/get_graspable_grocery_objects_from_masks3d/include/get_graspable_grocery_objects_from_masks3d/get_graspable_grocery_objects_from_masks3d.hpp
+++ b/src/get_graspable_grocery_objects_from_masks3d/include/get_graspable_grocery_objects_from_masks3d/get_graspable_grocery_objects_from_masks3d.hpp
@@ -1,0 +1,65 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <behaviortree_cpp/basic_types.h>
+
+#include <moveit_pro_behavior_interface/async_behavior_base.hpp>
+#include <rclcpp/publisher.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+namespace get_graspable_grocery_objects_from_masks3d
+{
+
+/**
+ * @brief Creates graspable objects from 3D masks, fitting the best primitive shape (box, cylinder, or sphere).
+ *
+ * @details For each point cloud segment defined by a 3D mask, this behavior fits three primitive shapes
+ * (box, cylinder, sphere) and selects the one with the smallest bounding volume. The fitted shape type
+ * is stored in the GraspInfo's object_type field as "box", "cylinder", or "sphere", and the bounding_volume
+ * primitive is set to the corresponding shape_msgs::SolidPrimitive type.
+ *
+ * | Data Port Name            | Port Type | Object Type                                         |
+ * | --------------------------| --------- | --------------------------------------------------- |
+ * | point_cloud               | input     | sensor_msgs::msg::PointCloud2                       |
+ * | masks3d                   | input     | std::vector<moveit_studio_vision_msgs::msg::Mask3D> |
+ * | base_frame                | input     | std::string                                         |
+ * | plane_inlier_threshold    | input     | double                                              |
+ * | minimum_face_area         | input     | double                                              |
+ * | face_separation_threshold | input     | double                                              |
+ * | graspable_objects         | output    | std::vector<moveit_studio_vision_msgs::msg::GraspableObject> |
+ */
+class GetGraspableGroceryObjectsFromMasks3D final : public moveit_pro::behaviors::AsyncBehaviorBase
+{
+public:
+  /**
+   * @param name Name of this behavior tree node.
+   * @param config Node configuration.
+   * @param shared_resources Shared behavior context with ROS node, TF buffer, etc.
+   */
+  GetGraspableGroceryObjectsFromMasks3D(const std::string& name, const BT::NodeConfiguration& config,
+                                        const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+protected:
+  tl::expected<bool, std::string> doWork() override;
+
+private:
+  std::shared_future<tl::expected<bool, std::string>>& getFuture() override
+  {
+    return future_;
+  }
+
+  std::shared_future<tl::expected<bool, std::string>> future_;
+
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
+};
+
+}  // namespace get_graspable_grocery_objects_from_masks3d

--- a/src/get_graspable_grocery_objects_from_masks3d/include/get_graspable_grocery_objects_from_masks3d/shape_fitting.hpp
+++ b/src/get_graspable_grocery_objects_from_masks3d/include/get_graspable_grocery_objects_from_masks3d/shape_fitting.hpp
@@ -1,0 +1,84 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <pcl/PointIndices.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <Eigen/Dense>
+#include <shape_msgs/msg/solid_primitive.hpp>
+#include <string>
+#include <tl_expected/expected.hpp>
+
+namespace get_graspable_grocery_objects_from_masks3d
+{
+
+/**
+ * @brief Result of fitting a primitive shape to a point cloud segment.
+ */
+struct ShapeFitResult
+{
+  /** @brief The fitted primitive (BOX, CYLINDER, or SPHERE). */
+  shape_msgs::msg::SolidPrimitive primitive;
+
+  /** @brief Transform from the cloud frame to the shape's principal-axis-aligned frame. */
+  Eigen::Isometry3d origin;
+
+  /** @brief Bounding volume of the fitted shape in cubic meters. */
+  double volume;
+
+  /** @brief Human-readable shape type: "box", "cylinder", or "sphere". */
+  std::string shape_type;
+};
+
+/**
+ * @brief Fit a principal-axis-aligned bounding box to the point cloud segment.
+ * @param cloud Input point cloud.
+ * @param indices Indices of points in this segment.
+ * @return ShapeFitResult for a BOX, or error string.
+ */
+[[nodiscard]] tl::expected<ShapeFitResult, std::string>
+fitBox(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+       const std::shared_ptr<const pcl::PointIndices>& indices);
+
+/**
+ * @brief Fit a cylinder to the point cloud segment using RANSAC.
+ * @param cloud Input point cloud.
+ * @param indices Indices of points in this segment.
+ * @param distance_threshold RANSAC inlier distance threshold in meters.
+ * @return ShapeFitResult for a CYLINDER, or error string.
+ */
+[[nodiscard]] tl::expected<ShapeFitResult, std::string>
+fitCylinder(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+            const std::shared_ptr<const pcl::PointIndices>& indices, double distance_threshold);
+
+/**
+ * @brief Fit a sphere to the point cloud segment using RANSAC.
+ * @param cloud Input point cloud.
+ * @param indices Indices of points in this segment.
+ * @param distance_threshold RANSAC inlier distance threshold in meters.
+ * @return ShapeFitResult for a SPHERE, or error string.
+ */
+[[nodiscard]] tl::expected<ShapeFitResult, std::string>
+fitSphere(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+          const std::shared_ptr<const pcl::PointIndices>& indices, double distance_threshold);
+
+/**
+ * @brief Fit box, cylinder, and sphere to a point cloud segment and return the best fit.
+ * @details The best fit is selected by smallest bounding volume. This assumes the tightest
+ *          enclosing primitive is the most representative shape for the object.
+ * @param cloud Input point cloud.
+ * @param indices Indices of points in this segment.
+ * @param distance_threshold RANSAC inlier distance threshold for cylinder/sphere fitting.
+ * @return The ShapeFitResult with the smallest volume, or error string if all fits fail.
+ */
+[[nodiscard]] tl::expected<ShapeFitResult, std::string>
+fitBestShape(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+             const std::shared_ptr<const pcl::PointIndices>& indices, double distance_threshold);
+
+}  // namespace get_graspable_grocery_objects_from_masks3d

--- a/src/get_graspable_grocery_objects_from_masks3d/package.xml
+++ b/src/get_graspable_grocery_objects_from_masks3d/package.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package format="3">
+  <name>get_graspable_grocery_objects_from_masks3d</name>
+  <version>0.0.0</version>
+  <description>Fits best primitive shape (box, cylinder, or sphere) to point cloud segments from 3D masks.</description>
+
+  <maintainer email="support@picknik.ai">
+    MoveIt Pro User
+  </maintainer>
+  <author email="support@picknik.ai">
+    MoveIt Pro User
+  </author>
+
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_pro_package</build_depend>
+
+  <depend>moveit_pro_behavior_interface</depend>
+  <depend>moveit_studio_vision_msgs</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
+  <depend>sensor_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+  <buildtool_depend>python3-colcon-common-extensions</buildtool_depend>
+</package>

--- a/src/get_graspable_grocery_objects_from_masks3d/src/compute_grocery_place_height.cpp
+++ b/src/get_graspable_grocery_objects_from_masks3d/src/compute_grocery_place_height.cpp
@@ -1,0 +1,125 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <get_graspable_grocery_objects_from_masks3d/compute_grocery_place_height.hpp>
+
+#include <algorithm>
+#include <shape_msgs/msg/solid_primitive.hpp>
+#include <spdlog/spdlog.h>
+
+namespace
+{
+constexpr auto kPortIDGraspableObject = "graspable_object";
+constexpr auto kPortIDPlaceHeight = "place_height";
+constexpr auto kPortIDShapeType = "shape_type";
+}  // namespace
+
+namespace get_graspable_grocery_objects_from_masks3d
+{
+
+ComputeGroceryPlaceHeight::ComputeGroceryPlaceHeight(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList ComputeGroceryPlaceHeight::providedPorts()
+{
+  return {
+    BT::InputPort<moveit_studio_vision_msgs::msg::GraspableObject>(
+        kPortIDGraspableObject, "{graspable_object}",
+        "GraspableObject with fitted shape. The grasp_info.object_type field must be set to "
+        "\"box\", \"cylinder\", or \"sphere\"."),
+    BT::OutputPort<double>(kPortIDPlaceHeight, "{place_height}",
+                           "Computed height above shelf target for grasp_link placement, in meters."),
+    BT::OutputPort<std::string>(kPortIDShapeType, "{shape_type}",
+                                "The detected shape type: \"box\", \"cylinder\", or \"sphere\"."),
+  };
+}
+
+BT::KeyValueVector ComputeGroceryPlaceHeight::metadata()
+{
+  return { { "description",
+             "Computes the place height for a grocery item based on its fitted shape and grasp convention. "
+             "Box (grasped at center): half longest dimension. "
+             "Cylinder (grasped on top): full height. "
+             "Sphere (grasped anywhere): full diameter." },
+           { "subcategory", "Perception - 3D" } };
+}
+
+BT::NodeStatus ComputeGroceryPlaceHeight::tick()
+{
+  const auto object_input =
+      getInput<moveit_studio_vision_msgs::msg::GraspableObject>(kPortIDGraspableObject);
+
+  if (!object_input.has_value())
+  {
+    spdlog::error("ComputeGroceryPlaceHeight: failed to get graspable_object input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto& object = object_input.value();
+  const auto& bv = object.grasp_info.bounding_volume;
+  const std::string shape_type = object.grasp_info.object_type;
+
+  double place_height = 0.0;
+
+  if (shape_type == "box")
+  {
+    if (bv.type != shape_msgs::msg::SolidPrimitive::BOX || bv.dimensions.size() < 3)
+    {
+      spdlog::error("ComputeGroceryPlaceHeight: object_type is 'box' but bounding_volume is not a valid BOX.");
+      return BT::NodeStatus::FAILURE;
+    }
+    // Grasped at the center of a face. The longest dimension is the axis that will be vertical.
+    // Place height = half of the longest dimension so the bottom touches the shelf.
+    const double longest_dim = std::max({ bv.dimensions[0], bv.dimensions[1], bv.dimensions[2] });
+    place_height = longest_dim / 2.0;
+    spdlog::info("ComputeGroceryPlaceHeight: box dims=[{:.4f}, {:.4f}, {:.4f}], longest={:.4f}, place_height={:.4f}",
+                 bv.dimensions[0], bv.dimensions[1], bv.dimensions[2], longest_dim, place_height);
+  }
+  else if (shape_type == "cylinder")
+  {
+    if (bv.type != shape_msgs::msg::SolidPrimitive::CYLINDER || bv.dimensions.size() < 2)
+    {
+      spdlog::error(
+          "ComputeGroceryPlaceHeight: object_type is 'cylinder' but bounding_volume is not a valid CYLINDER.");
+      return BT::NodeStatus::FAILURE;
+    }
+    // CYLINDER dimensions: [height, radius].
+    // Grasped on the top flat face. Place height = full height of the cylinder.
+    const double height = bv.dimensions[0];
+    place_height = height;
+    spdlog::info("ComputeGroceryPlaceHeight: cylinder height={:.4f}, radius={:.4f}, place_height={:.4f}",
+                 bv.dimensions[0], bv.dimensions[1], place_height);
+  }
+  else if (shape_type == "sphere")
+  {
+    if (bv.type != shape_msgs::msg::SolidPrimitive::SPHERE || bv.dimensions.empty())
+    {
+      spdlog::error("ComputeGroceryPlaceHeight: object_type is 'sphere' but bounding_volume is not a valid SPHERE.");
+      return BT::NodeStatus::FAILURE;
+    }
+    // SPHERE dimensions: [radius].
+    // Grasped anywhere. Place height = full diameter so the bottom touches the shelf.
+    const double radius = bv.dimensions[0];
+    place_height = radius * 2.0;
+    spdlog::info("ComputeGroceryPlaceHeight: sphere radius={:.4f}, place_height={:.4f}", radius, place_height);
+  }
+  else
+  {
+    spdlog::error("ComputeGroceryPlaceHeight: unknown shape type '{}'. Expected 'box', 'cylinder', or 'sphere'.",
+                  shape_type);
+    return BT::NodeStatus::FAILURE;
+  }
+
+  setOutput(kPortIDPlaceHeight, place_height);
+  setOutput(kPortIDShapeType, shape_type);
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace get_graspable_grocery_objects_from_masks3d

--- a/src/get_graspable_grocery_objects_from_masks3d/src/get_graspable_grocery_objects_from_masks3d.cpp
+++ b/src/get_graspable_grocery_objects_from_masks3d/src/get_graspable_grocery_objects_from_masks3d.cpp
@@ -1,0 +1,270 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <get_graspable_grocery_objects_from_masks3d/get_graspable_grocery_objects_from_masks3d.hpp>
+#include <get_graspable_grocery_objects_from_masks3d/shape_fitting.hpp>
+
+#include <pcl_conversions/pcl_conversions.h>
+#include <spdlog/spdlog.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_studio_vision_msgs/msg/graspable_object.hpp>
+#include <moveit_studio_vision_msgs/msg/mask3_d.hpp>
+#include <moveit_studio_vision_msgs/msg/object_subframe.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <shape_msgs/msg/solid_primitive.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_ros/buffer.h>
+
+namespace
+{
+inline constexpr auto kDescriptionGetGraspableGroceryObjectsFromMasks3D = R"(
+                <p>
+                    Creates graspable objects from 3D masks by fitting the best primitive shape
+                    (box, cylinder, or sphere) to each point cloud segment. The fitted shape type
+                    is stored in the object_type field of GraspInfo.
+                </p>
+            )";
+
+constexpr auto kPortIDPointCloud = "point_cloud";
+constexpr auto kPortIDMasks3D = "masks3d";
+constexpr auto kPortIDBaseFrame = "base_frame";
+constexpr auto kPortIDPlaneInlierThreshold = "plane_inlier_threshold";
+constexpr auto kPortIDMinimumFaceArea = "minimum_face_area";
+constexpr auto kPortIDFaceSeparationThreshold = "face_separation_threshold";
+constexpr auto kPortIDGraspableObjects = "graspable_objects";
+
+constexpr auto kMarkerTopic = "/visual_markers";
+constexpr auto kMarkerNamespace = "grocery_objects";
+
+const auto kTFLookupTimeoutSeconds = std::chrono::duration<double>{ 0.1 };
+
+/** @brief Create a visualization marker for a shape fit result. */
+visualization_msgs::msg::Marker createShapeMarker(
+    const get_graspable_grocery_objects_from_masks3d::ShapeFitResult& fit, const Eigen::Isometry3d& tform_base_to_cloud,
+    const std::string& frame_id, int id)
+{
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.header.frame_id = frame_id;
+  m.id = id;
+  m.ns = kMarkerNamespace;
+  m.color.r = 0.2f;
+  m.color.g = 1.0f;
+  m.color.b = 0.4f;
+  m.color.a = 0.5f;
+  m.lifetime.sec = 15;
+  m.pose = tf2::toMsg(tform_base_to_cloud * fit.origin);
+
+  if (fit.primitive.type == shape_msgs::msg::SolidPrimitive::BOX)
+  {
+    m.type = visualization_msgs::msg::Marker::CUBE;
+    m.scale.x = fit.primitive.dimensions[0];
+    m.scale.y = fit.primitive.dimensions[1];
+    m.scale.z = fit.primitive.dimensions[2];
+  }
+  else if (fit.primitive.type == shape_msgs::msg::SolidPrimitive::CYLINDER)
+  {
+    m.type = visualization_msgs::msg::Marker::CYLINDER;
+    m.scale.x = fit.primitive.dimensions[1] * 2.0;  // diameter
+    m.scale.y = fit.primitive.dimensions[1] * 2.0;  // diameter
+    m.scale.z = fit.primitive.dimensions[0];         // height
+  }
+  else if (fit.primitive.type == shape_msgs::msg::SolidPrimitive::SPHERE)
+  {
+    m.type = visualization_msgs::msg::Marker::SPHERE;
+    const double diameter = fit.primitive.dimensions[0] * 2.0;
+    m.scale.x = diameter;
+    m.scale.y = diameter;
+    m.scale.z = diameter;
+  }
+
+  return m;
+}
+
+/** @brief Create a text marker labeling the shape type. */
+visualization_msgs::msg::Marker createLabelMarker(const get_graspable_grocery_objects_from_masks3d::ShapeFitResult& fit,
+                                                   const Eigen::Isometry3d& tform_base_to_cloud,
+                                                   const std::string& frame_id, int id)
+{
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.header.frame_id = frame_id;
+  m.id = id;
+  m.ns = kMarkerNamespace;
+  m.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+  m.text = fit.shape_type;
+  m.color.r = 1.0f;
+  m.color.g = 1.0f;
+  m.color.b = 1.0f;
+  m.color.a = 1.0f;
+  m.scale.z = 0.03;
+  m.lifetime.sec = 15;
+
+  auto pose = tform_base_to_cloud * fit.origin;
+  pose.translation().z() += 0.05;
+  m.pose = tf2::toMsg(pose);
+
+  return m;
+}
+}  // namespace
+
+namespace get_graspable_grocery_objects_from_masks3d
+{
+
+GetGraspableGroceryObjectsFromMasks3D::GetGraspableGroceryObjectsFromMasks3D(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : AsyncBehaviorBase(name, config, shared_resources)
+{
+  marker_pub_ = shared_resources->node->create_publisher<visualization_msgs::msg::MarkerArray>(
+      kMarkerTopic, rclcpp::QoS(1).transient_local());
+}
+
+BT::PortsList GetGraspableGroceryObjectsFromMasks3D::providedPorts()
+{
+  return {
+    BT::InputPort<sensor_msgs::msg::PointCloud2>(kPortIDPointCloud, "{point_cloud}", "Input point cloud."),
+    BT::InputPort<std::vector<moveit_studio_vision_msgs::msg::Mask3D>>(kPortIDMasks3D, "{masks3d}",
+                                                                       "3D masks selecting subsets of points."),
+    BT::InputPort<std::string>(kPortIDBaseFrame, "world",
+                               "Calculate poses of graspable objects relative to this frame."),
+    BT::InputPort<double>(kPortIDPlaneInlierThreshold, 0.01,
+                          "Distance threshold in meters for RANSAC shape fitting."),
+    BT::InputPort<double>(kPortIDMinimumFaceArea, 0.000625,
+                          "Minimum area in meters^2 for a face to be considered graspable."),
+    BT::InputPort<double>(kPortIDFaceSeparationThreshold, 0.01,
+                          "Distance in meters between coplanar clusters to split them into separate faces."),
+    BT::OutputPort<std::vector<moveit_studio_vision_msgs::msg::GraspableObject>>(
+        kPortIDGraspableObjects, "{graspable_objects}",
+        "Vector of graspable objects with best-fit primitive shapes."),
+  };
+}
+
+BT::KeyValueVector GetGraspableGroceryObjectsFromMasks3D::metadata()
+{
+  return { { "subcategory", "Perception - 3D" },
+           { "description", kDescriptionGetGraspableGroceryObjectsFromMasks3D } };
+}
+
+tl::expected<bool, std::string> GetGraspableGroceryObjectsFromMasks3D::doWork()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(
+      getInput<sensor_msgs::msg::PointCloud2>(kPortIDPointCloud),
+      getInput<std::vector<moveit_studio_vision_msgs::msg::Mask3D>>(kPortIDMasks3D),
+      getInput<std::string>(kPortIDBaseFrame), getInput<double>(kPortIDPlaneInlierThreshold),
+      getInput<double>(kPortIDMinimumFaceArea), getInput<double>(kPortIDFaceSeparationThreshold));
+
+  if (!ports.has_value())
+  {
+    return tl::make_unexpected("Failed to get required value from input data port: " + ports.error());
+  }
+
+  const auto& [point_cloud_msg, masks, base_frame, plane_inlier_threshold, minimum_face_area,
+               face_separation_threshold] = ports.value();
+
+  if (masks.empty())
+  {
+    return tl::make_unexpected("There are no input masks to create graspable objects.");
+  }
+
+  // Convert ROS point cloud to PCL.
+  const auto point_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+  pcl::fromROSMsg(point_cloud_msg, *point_cloud);
+
+  // Look up transform from base frame to cloud frame.
+  Eigen::Isometry3d tform_base_to_cloud;
+  try
+  {
+    tform_base_to_cloud = tf2::transformToEigen(shared_resources_->transform_buffer_ptr->lookupTransform(
+        base_frame, point_cloud_msg.header.frame_id, tf2_ros::fromMsg(point_cloud_msg.header.stamp),
+        tf2::durationFromSec(kTFLookupTimeoutSeconds.count())));
+  }
+  catch (const std::exception& e)
+  {
+    return tl::make_unexpected(
+        std::string("Failed to look up transform from base frame to point cloud origin frame: ") + e.what());
+  }
+
+  // Clear previous markers.
+  visualization_msgs::msg::MarkerArray marker_array;
+  visualization_msgs::msg::Marker delete_marker;
+  delete_marker.action = visualization_msgs::msg::Marker::DELETEALL;
+  delete_marker.ns = kMarkerNamespace;
+  marker_array.markers.push_back(delete_marker);
+
+  std::vector<moveit_studio_vision_msgs::msg::GraspableObject> graspable_objects;
+  graspable_objects.reserve(masks.size());
+  int marker_id = 0;
+
+  for (std::size_t i = 0; i < masks.size(); ++i)
+  {
+    const auto& mask = masks[i];
+    const auto mask_indices = std::make_shared<pcl::PointIndices>();
+    mask_indices->header = point_cloud->header;
+    mask_indices->indices = mask.point_indices;
+
+    spdlog::info("Fitting shapes to mask {} ({} points)...", i, mask.point_indices.size());
+
+    const auto fit_result = fitBestShape(
+        std::const_pointer_cast<const pcl::PointCloud<pcl::PointXYZRGB>>(point_cloud),
+        std::const_pointer_cast<const pcl::PointIndices>(mask_indices), plane_inlier_threshold);
+
+    if (!fit_result.has_value())
+    {
+      spdlog::warn("Unable to fit shape to mask {}: {}", i, fit_result.error());
+      continue;
+    }
+
+    const auto& fit = fit_result.value();
+
+    // Build the GraspableObject message.
+    moveit_studio_vision_msgs::msg::GraspableObject graspable_object;
+    const std::string label = std::string("object_").append(std::to_string(i));
+    graspable_object.object.id = label;
+    graspable_object.object.header.frame_id = base_frame;
+    graspable_object.object.header.stamp = builtin_interfaces::msg::Time();
+    graspable_object.object.pose = tf2::toMsg(tform_base_to_cloud * fit.origin);
+
+    // Set the bounding volume to the fitted primitive.
+    graspable_object.grasp_info.bounding_volume = fit.primitive;
+
+    // Also store as a collision primitive.
+    graspable_object.object.primitives.push_back(fit.primitive);
+    graspable_object.object.primitive_poses.push_back(tf2::toMsg(Eigen::Isometry3d::Identity()));
+
+    // Store the shape type for downstream behaviors to use.
+    graspable_object.grasp_info.object_type = fit.shape_type;
+
+    // Add a subframe named after the shape type.
+    moveit_studio_vision_msgs::msg::ObjectSubframe subframe;
+    subframe.id = fit.shape_type;
+    subframe.pose = tf2::toMsg(Eigen::Isometry3d::Identity());
+    graspable_object.grasp_info.subframes.push_back(subframe);
+
+    graspable_objects.push_back(graspable_object);
+
+    // Create visualization markers.
+    marker_array.markers.push_back(createShapeMarker(fit, tform_base_to_cloud, base_frame, marker_id++));
+    marker_array.markers.push_back(createLabelMarker(fit, tform_base_to_cloud, base_frame, marker_id++));
+
+    spdlog::info("Object {}: {} (volume={:.6f} m^3)", i, fit.shape_type, fit.volume);
+  }
+
+  marker_pub_->publish(marker_array);
+
+  if (graspable_objects.empty())
+  {
+    return tl::make_unexpected("Could not create any graspable objects from the masked point cloud fragments.");
+  }
+
+  setOutput(kPortIDGraspableObjects, graspable_objects);
+
+  spdlog::info("GetGraspableGroceryObjectsFromMasks3D: created {} graspable objects.", graspable_objects.size());
+  return true;
+}
+
+}  // namespace get_graspable_grocery_objects_from_masks3d

--- a/src/get_graspable_grocery_objects_from_masks3d/src/register_behaviors.cpp
+++ b/src/get_graspable_grocery_objects_from_masks3d/src/register_behaviors.cpp
@@ -1,0 +1,36 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <get_graspable_grocery_objects_from_masks3d/compute_grocery_place_height.hpp>
+#include <get_graspable_grocery_objects_from_masks3d/get_graspable_grocery_objects_from_masks3d.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace get_graspable_grocery_objects_from_masks3d
+{
+class GetGraspableGroceryObjectsFromMasks3DBehaviorsLoader
+  : public moveit_pro::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(
+      BT::BehaviorTreeFactory& factory,
+      [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_pro::behaviors::registerBehavior<ComputeGroceryPlaceHeight>(
+        factory, "ComputeGroceryPlaceHeight", shared_resources);
+    moveit_pro::behaviors::registerBehavior<GetGraspableGroceryObjectsFromMasks3D>(
+        factory, "GetGraspableGroceryObjectsFromMasks3D", shared_resources);
+  }
+};
+}  // namespace get_graspable_grocery_objects_from_masks3d
+
+PLUGINLIB_EXPORT_CLASS(
+    get_graspable_grocery_objects_from_masks3d::GetGraspableGroceryObjectsFromMasks3DBehaviorsLoader,
+    moveit_pro::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/get_graspable_grocery_objects_from_masks3d/src/shape_fitting.cpp
+++ b/src/get_graspable_grocery_objects_from_masks3d/src/shape_fitting.cpp
@@ -1,0 +1,283 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <get_graspable_grocery_objects_from_masks3d/shape_fitting.hpp>
+
+#include <pcl/common/centroid.h>
+#include <pcl/common/common.h>
+#include <pcl/common/pca.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/sample_consensus/method_types.h>
+#include <pcl/sample_consensus/model_types.h>
+#include <pcl/search/kdtree.h>
+#include <pcl/segmentation/sac_segmentation.h>
+
+#include <cmath>
+#include <spdlog/spdlog.h>
+
+namespace get_graspable_grocery_objects_from_masks3d
+{
+namespace
+{
+constexpr int kMinPointsForFitting = 10;
+constexpr int kRansacMaxIterations = 1000;
+constexpr double kPi = 3.14159265358979323846;
+
+/** @brief Extract the subset of points from a cloud given indices. */
+[[nodiscard]] pcl::PointCloud<pcl::PointXYZRGB>::Ptr
+extractPoints(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+              const std::shared_ptr<const pcl::PointIndices>& indices)
+{
+  auto subset = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+  subset->points.reserve(indices->indices.size());
+  for (const int idx : indices->indices)
+  {
+    subset->points.push_back(cloud->points[idx]);
+  }
+  subset->width = subset->points.size();
+  subset->height = 1;
+  subset->is_dense = false;
+  return subset;
+}
+}  // namespace
+
+tl::expected<ShapeFitResult, std::string>
+fitBox(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+       const std::shared_ptr<const pcl::PointIndices>& indices)
+{
+  if (static_cast<int>(indices->indices.size()) < kMinPointsForFitting)
+  {
+    return tl::make_unexpected("Too few points for box fitting.");
+  }
+
+  const auto subset = extractPoints(cloud, indices);
+
+  // Compute PCA to get principal axes.
+  pcl::PCA<pcl::PointXYZRGB> pca;
+  pca.setInputCloud(subset);
+
+  const Eigen::Vector4f centroid_4f = pca.getMean();
+  const Eigen::Vector3f centroid = centroid_4f.head<3>();
+  const Eigen::Matrix3f eigenvectors = pca.getEigenVectors();
+
+  // Build transform from cloud frame to PCA-aligned frame.
+  Eigen::Isometry3d origin = Eigen::Isometry3d::Identity();
+  origin.translation() = centroid.cast<double>();
+  origin.linear() = eigenvectors.cast<double>();
+
+  // Project points into PCA frame and find extents.
+  Eigen::Vector3f min_pt(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(),
+                         std::numeric_limits<float>::max());
+  Eigen::Vector3f max_pt(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(),
+                         std::numeric_limits<float>::lowest());
+
+  for (const auto& pt : subset->points)
+  {
+    const Eigen::Vector3f local = eigenvectors.transpose() * (Eigen::Vector3f(pt.x, pt.y, pt.z) - centroid);
+    min_pt = min_pt.cwiseMin(local);
+    max_pt = max_pt.cwiseMax(local);
+  }
+
+  const Eigen::Vector3f size = max_pt - min_pt;
+  const Eigen::Vector3f box_center_local = (min_pt + max_pt) * 0.5f;
+
+  // Adjust origin to be at the center of the bounding box.
+  origin.translation() += (eigenvectors * box_center_local).cast<double>();
+
+  ShapeFitResult result;
+  result.origin = origin;
+  result.shape_type = "box";
+  result.primitive.type = shape_msgs::msg::SolidPrimitive::BOX;
+  result.primitive.dimensions = { static_cast<double>(size.x()), static_cast<double>(size.y()),
+                                  static_cast<double>(size.z()) };
+  result.volume = static_cast<double>(size.x()) * static_cast<double>(size.y()) * static_cast<double>(size.z());
+
+  return result;
+}
+
+tl::expected<ShapeFitResult, std::string>
+fitCylinder(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+            const std::shared_ptr<const pcl::PointIndices>& indices, double distance_threshold)
+{
+  if (static_cast<int>(indices->indices.size()) < kMinPointsForFitting)
+  {
+    return tl::make_unexpected("Too few points for cylinder fitting.");
+  }
+
+  const auto subset = extractPoints(cloud, indices);
+
+  // Estimate normals for cylinder fitting.
+  // PCL's cylinder RANSAC requires normals, so we use PCA-based normal estimation.
+  auto normals = std::make_shared<pcl::PointCloud<pcl::Normal>>();
+  pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZRGB>());
+  pcl::NormalEstimation<pcl::PointXYZRGB, pcl::Normal> ne;
+  ne.setSearchMethod(tree);
+  ne.setInputCloud(subset);
+  ne.setKSearch(15);
+  ne.compute(*normals);
+
+  pcl::SACSegmentationFromNormals<pcl::PointXYZRGB, pcl::Normal> seg;
+  seg.setOptimizeCoefficients(true);
+  seg.setModelType(pcl::SACMODEL_CYLINDER);
+  seg.setMethodType(pcl::SAC_RANSAC);
+  seg.setMaxIterations(kRansacMaxIterations);
+  seg.setDistanceThreshold(distance_threshold);
+  seg.setRadiusLimits(0.005, 0.15);
+  seg.setNormalDistanceWeight(0.1);
+  seg.setInputCloud(subset);
+  seg.setInputNormals(normals);
+
+  pcl::PointIndices inlier_indices;
+  pcl::ModelCoefficients coefficients;
+  seg.segment(inlier_indices, coefficients);
+
+  if (inlier_indices.indices.empty() || coefficients.values.size() < 7)
+  {
+    return tl::make_unexpected("Cylinder RANSAC failed to fit a model.");
+  }
+
+  // Cylinder coefficients: [point_on_axis.x, point_on_axis.y, point_on_axis.z, axis.x, axis.y, axis.z, radius].
+  const Eigen::Vector3d axis_point(coefficients.values[0], coefficients.values[1], coefficients.values[2]);
+  const Eigen::Vector3d axis_dir(coefficients.values[3], coefficients.values[4], coefficients.values[5]);
+  const double radius = std::abs(coefficients.values[6]);
+
+  // Project all points onto the axis to find the height extent.
+  const Eigen::Vector3d axis_normalized = axis_dir.normalized();
+  double min_proj = std::numeric_limits<double>::max();
+  double max_proj = std::numeric_limits<double>::lowest();
+
+  for (const auto& pt : subset->points)
+  {
+    const Eigen::Vector3d p(pt.x, pt.y, pt.z);
+    const double proj = (p - axis_point).dot(axis_normalized);
+    min_proj = std::min(min_proj, proj);
+    max_proj = std::max(max_proj, proj);
+  }
+
+  const double height = max_proj - min_proj;
+  const double center_proj = (min_proj + max_proj) * 0.5;
+  const Eigen::Vector3d center = axis_point + center_proj * axis_normalized;
+
+  // Build the transform with the Z axis along the cylinder axis.
+  Eigen::Isometry3d origin = Eigen::Isometry3d::Identity();
+  origin.translation() = center;
+
+  // Construct a rotation matrix where Z aligns with the cylinder axis.
+  const Eigen::Vector3d z_axis = axis_normalized;
+  Eigen::Vector3d x_axis = Eigen::Vector3d::UnitX();
+  if (std::abs(z_axis.dot(x_axis)) > 0.9)
+  {
+    x_axis = Eigen::Vector3d::UnitY();
+  }
+  const Eigen::Vector3d y_axis = z_axis.cross(x_axis).normalized();
+  x_axis = y_axis.cross(z_axis).normalized();
+
+  Eigen::Matrix3d rotation;
+  rotation.col(0) = x_axis;
+  rotation.col(1) = y_axis;
+  rotation.col(2) = z_axis;
+  origin.linear() = rotation;
+
+  ShapeFitResult result;
+  result.origin = origin;
+  result.shape_type = "cylinder";
+  result.primitive.type = shape_msgs::msg::SolidPrimitive::CYLINDER;
+  // CYLINDER dimensions: [height, radius].
+  result.primitive.dimensions = { height, radius };
+  result.volume = kPi * radius * radius * height;
+
+  return result;
+}
+
+tl::expected<ShapeFitResult, std::string>
+fitSphere(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+          const std::shared_ptr<const pcl::PointIndices>& indices, double distance_threshold)
+{
+  if (static_cast<int>(indices->indices.size()) < kMinPointsForFitting)
+  {
+    return tl::make_unexpected("Too few points for sphere fitting.");
+  }
+
+  const auto subset = extractPoints(cloud, indices);
+
+  pcl::SACSegmentation<pcl::PointXYZRGB> seg;
+  seg.setOptimizeCoefficients(true);
+  seg.setModelType(pcl::SACMODEL_SPHERE);
+  seg.setMethodType(pcl::SAC_RANSAC);
+  seg.setMaxIterations(kRansacMaxIterations);
+  seg.setDistanceThreshold(distance_threshold);
+  seg.setRadiusLimits(0.01, 0.15);
+  seg.setInputCloud(subset);
+
+  pcl::PointIndices inlier_indices;
+  pcl::ModelCoefficients coefficients;
+  seg.segment(inlier_indices, coefficients);
+
+  if (inlier_indices.indices.empty() || coefficients.values.size() < 4)
+  {
+    return tl::make_unexpected("Sphere RANSAC failed to fit a model.");
+  }
+
+  // Sphere coefficients: [center.x, center.y, center.z, radius].
+  const Eigen::Vector3d center(coefficients.values[0], coefficients.values[1], coefficients.values[2]);
+  const double radius = std::abs(coefficients.values[3]);
+
+  ShapeFitResult result;
+  result.origin = Eigen::Isometry3d::Identity();
+  result.origin.translation() = center;
+  result.shape_type = "sphere";
+  result.primitive.type = shape_msgs::msg::SolidPrimitive::SPHERE;
+  // SPHERE dimensions: [radius].
+  result.primitive.dimensions = { radius };
+  result.volume = (4.0 / 3.0) * kPi * radius * radius * radius;
+
+  return result;
+}
+
+tl::expected<ShapeFitResult, std::string>
+fitBestShape(const std::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB>>& cloud,
+             const std::shared_ptr<const pcl::PointIndices>& indices, double distance_threshold)
+{
+  const auto box_result = fitBox(cloud, indices);
+  const auto cylinder_result = fitCylinder(cloud, indices, distance_threshold);
+  const auto sphere_result = fitSphere(cloud, indices, distance_threshold);
+
+  // Collect successful fits.
+  std::vector<ShapeFitResult> candidates;
+  if (box_result.has_value())
+  {
+    spdlog::info("  Box fit: volume={:.6f} m^3, dims=[{:.4f}, {:.4f}, {:.4f}]", box_result->volume,
+                 box_result->primitive.dimensions[0], box_result->primitive.dimensions[1],
+                 box_result->primitive.dimensions[2]);
+    candidates.push_back(box_result.value());
+  }
+  if (cylinder_result.has_value())
+  {
+    spdlog::info("  Cylinder fit: volume={:.6f} m^3, height={:.4f}, radius={:.4f}", cylinder_result->volume,
+                 cylinder_result->primitive.dimensions[0], cylinder_result->primitive.dimensions[1]);
+    candidates.push_back(cylinder_result.value());
+  }
+  if (sphere_result.has_value())
+  {
+    spdlog::info("  Sphere fit: volume={:.6f} m^3, radius={:.4f}", sphere_result->volume,
+                 sphere_result->primitive.dimensions[0]);
+    candidates.push_back(sphere_result.value());
+  }
+
+  if (candidates.empty())
+  {
+    return tl::make_unexpected("All shape fitting methods failed.");
+  }
+
+  // Select the candidate with the smallest bounding volume.
+  auto best = std::min_element(candidates.begin(), candidates.end(),
+                               [](const ShapeFitResult& a, const ShapeFitResult& b) { return a.volume < b.volume; });
+
+  spdlog::info("  Best fit: {} (volume={:.6f} m^3)", best->shape_type, best->volume);
+  return *best;
+}
+
+}  // namespace get_graspable_grocery_objects_from_masks3d

--- a/src/get_graspable_grocery_objects_from_masks3d/test/CMakeLists.txt
+++ b/src/get_graspable_grocery_objects_from_masks3d/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+# No tests yet


### PR DESCRIPTION
This is one of several PRs to break down https://github.com/PickNikRobotics/moveit_pro_ur_config/pull/10 into more reasonable chunks 

Add two new MoveIt Pro behavior packages:

- compute_place_orientation: Computes the target place orientation for picked objects based on their grasp pose and shape.

Takes the object pose perceived at pick time, the grasp link pose at pick time, the place position (the saved shelf target), the object height for vertical placement (for cylinders picked from their side, placement height is 1/2 object height, for cylinders picked from their top, placement height is object height, boxes are necessarily picked from their side so placement height is always 1/2 object height, and for spheres placement height is necessarily object diameter). -> outputs T_grasp_object and figures the grasp_link_orientation needed so the objects longest axis is placed upright. 

- get_graspable_grocery_objects_from_masks3d: Detects graspable grocery objects from Masks3D segmentation output, including shape fitting (cylinder/box detection) and grocery place height computation.