### PR TITLE
Add filter_graspable_objects behavior package

### DIFF
--- a/src/filter_graspable_objects/CMakeLists.txt
+++ b/src/filter_graspable_objects/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.22)
+project(filter_graspable_objects CXX)
+
+find_package(moveit_pro_package REQUIRED)
+moveit_pro_package()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS moveit_pro_behavior_interface moveit_studio_vision_msgs shape_msgs visualization_msgs pluginlib)
+foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${package} REQUIRED)
+endforeach()
+
+add_library(
+  filter_graspable_objects
+  SHARED
+  src/filter_graspable_objects.cpp
+  src/register_behaviors.cpp)
+target_include_directories(
+  filter_graspable_objects
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(filter_graspable_objects
+                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+# Install Libraries
+install(
+  TARGETS filter_graspable_objects
+  EXPORT filter_graspable_objectsTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES
+  DESTINATION include)
+
+if(BUILD_TESTING)
+  moveit_pro_behavior_test(filter_graspable_objects)
+endif()
+
+# Export the behavior plugins defined in this package so they are available to
+# plugin loaders that load the behavior base class library from the
+# moveit_pro_behavior package.
+pluginlib_export_plugin_description_file(
+  moveit_pro_behavior_interface filter_graspable_objects_plugin_description.xml)
+
+ament_export_targets(filter_graspable_objectsTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/filter_graspable_objects/behavior_plugin.yaml
+++ b/src/filter_graspable_objects/behavior_plugin.yaml
@@ -1,0 +1,4 @@
+objectives:
+  behavior_loader_plugins:
+    filter_graspable_objects:
+      - "filter_graspable_objects::FilterGraspableObjectsBehaviorsLoader"

--- a/src/filter_graspable_objects/filter_graspable_objects_plugin_description.xml
+++ b/src/filter_graspable_objects/filter_graspable_objects_plugin_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<library path="filter_graspable_objects">
+  <class
+    type="filter_graspable_objects::FilterGraspableObjectsBehaviorsLoader"
+    base_class_type="moveit_pro::behaviors::SharedResourcesNodeLoaderBase"
+  />
+</library>

--- a/src/filter_graspable_objects/include/filter_graspable_objects/filter_graspable_objects.hpp
+++ b/src/filter_graspable_objects/include/filter_graspable_objects/filter_graspable_objects.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+#include <moveit_studio_vision_msgs/msg/graspable_object.hpp>
+#include <rclcpp/publisher.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+namespace filter_graspable_objects
+{
+
+/**
+ * @brief Filters a vector of GraspableObjects by maximum linear dimension and optionally by volume.
+ *        Results are sorted by centroid height (highest Z first).
+ *        Publishes blue transparent markers for rejected objects and green for accepted.
+ */
+class FilterGraspableObjects final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  FilterGraspableObjects(const std::string& name, const BT::NodeConfiguration& config,
+                         const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+
+private:
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
+};
+
+}  // namespace filter_graspable_objects

--- a/src/filter_graspable_objects/package.xml
+++ b/src/filter_graspable_objects/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package format="3">
+  <name>filter_graspable_objects</name>
+  <version>0.0.0</version>
+  <description>This filters graspable objects by size.</description>
+
+  <maintainer email="support@picknik.ai">
+    MoveIt Pro User
+  </maintainer>
+  <author email="support@picknik.ai">
+    MoveIt Pro User
+  </author>
+
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_pro_package</build_depend>
+
+  <depend>moveit_pro_behavior_interface</depend>
+  <depend>moveit_studio_vision_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+  <buildtool_depend>python3-colcon-common-extensions</buildtool_depend>
+</package>

--- a/src/filter_graspable_objects/src/filter_graspable_objects.cpp
+++ b/src/filter_graspable_objects/src/filter_graspable_objects.cpp
@@ -1,0 +1,190 @@
+#include <filter_graspable_objects/filter_graspable_objects.hpp>
+
+#include <algorithm>
+#include <shape_msgs/msg/solid_primitive.hpp>
+#include <spdlog/spdlog.h>
+
+namespace
+{
+constexpr auto kPortIDObjectsIn = "objects_in";
+constexpr auto kPortIDObjectsOut = "objects_out";
+constexpr auto kPortIDMaxLinearDimension = "max_linear_dimension";
+constexpr auto kPortIDMaxVolumeCm3 = "max_volume_cm3";
+
+constexpr auto kMarkerTopic = "/visual_markers";
+constexpr auto kMarkerNamespace = "filter_graspable_objects";
+
+visualization_msgs::msg::Marker makeBoxMarker(
+    const moveit_studio_vision_msgs::msg::GraspableObject& obj,
+    int id, float r, float g, float b, float a)
+{
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.header = obj.object.header;
+  m.header.frame_id = "world";
+  m.id = id;
+  m.ns = kMarkerNamespace;
+  m.type = visualization_msgs::msg::Marker::CUBE;
+  m.pose = obj.object.pose;
+  m.color.r = r;
+  m.color.g = g;
+  m.color.b = b;
+  m.color.a = a;
+  m.lifetime.sec = 10;
+  const auto& bv = obj.grasp_info.bounding_volume;
+  if (bv.dimensions.size() >= 3)
+  {
+    m.scale.x = bv.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X];
+    m.scale.y = bv.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y];
+    m.scale.z = bv.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z];
+  }
+  return m;
+}
+}  // namespace
+
+namespace filter_graspable_objects
+{
+
+FilterGraspableObjects::FilterGraspableObjects(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+  marker_pub_ = shared_resources->node->create_publisher<visualization_msgs::msg::MarkerArray>(
+      kMarkerTopic, rclcpp::QoS(1).transient_local());
+}
+
+BT::PortsList FilterGraspableObjects::providedPorts()
+{
+  return BT::PortsList{
+    BT::InputPort<std::vector<moveit_studio_vision_msgs::msg::GraspableObject>>(
+        kPortIDObjectsIn, "{objects}", "Input vector of graspable objects to filter."),
+    BT::InputPort<double>(kPortIDMaxLinearDimension, "0.20",
+                          "Maximum allowed dimension along any single axis (meters)."),
+    BT::InputPort<double>(kPortIDMaxVolumeCm3, "-1.0",
+                          "Maximum allowed bounding volume in cubic centimeters. "
+                          "Set to <= 0 to skip volume filtering."),
+    BT::OutputPort<std::vector<moveit_studio_vision_msgs::msg::GraspableObject>>(
+        kPortIDObjectsOut, "{filtered_objects}", "Filtered and sorted graspable objects (highest centroid Z first)."),
+  };
+}
+
+BT::KeyValueVector FilterGraspableObjects::metadata()
+{
+  return { { "description",
+             "Filters graspable objects by maximum linear dimension and optionally by volume. "
+             "Results are sorted by centroid height (highest Z first). "
+             "Publishes blue markers for rejected objects and green for accepted." },
+           { "subcategory", "Perception - 3D" } };
+}
+
+BT::NodeStatus FilterGraspableObjects::tick()
+{
+  const auto objects_in =
+      getInput<std::vector<moveit_studio_vision_msgs::msg::GraspableObject>>(kPortIDObjectsIn);
+  const auto max_linear_dim = getInput<double>(kPortIDMaxLinearDimension);
+  const auto max_volume_cm3 = getInput<double>(kPortIDMaxVolumeCm3);
+
+  if (!objects_in.has_value() || !max_linear_dim.has_value())
+  {
+    spdlog::error("FilterGraspableObjects: failed to get required input ports.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const double max_dim = max_linear_dim.value();
+  const double max_vol = max_volume_cm3.has_value() ? max_volume_cm3.value() : -1.0;
+
+  spdlog::warn("=== FilterGraspableObjects: {} input objects, max_dim={:.3f}m, max_vol={:.1f}cm3 ===",
+               objects_in.value().size(), max_dim, max_vol);
+
+  std::vector<moveit_studio_vision_msgs::msg::GraspableObject> accepted;
+  std::vector<moveit_studio_vision_msgs::msg::GraspableObject> rejected;
+
+  int idx = 0;
+  for (const auto& obj : objects_in.value())
+  {
+    const auto& bv = obj.grasp_info.bounding_volume;
+
+    if (bv.type != shape_msgs::msg::SolidPrimitive::BOX || bv.dimensions.size() < 3)
+    {
+      spdlog::warn("  [{}] NON-BOX type={}, REJECTED", idx, bv.type);
+      rejected.push_back(obj);
+      ++idx;
+      continue;
+    }
+
+    const double dx = bv.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X];
+    const double dy = bv.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y];
+    const double dz = bv.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z];
+    const double largest_dim = std::max({ dx, dy, dz });
+    const double volume_cm3 = dx * dy * dz * 1e6;
+
+    spdlog::warn("  [{}] dims: {:.4f} x {:.4f} x {:.4f} m, largest={:.4f}m, vol={:.1f}cm3, pos=({:.3f},{:.3f},{:.3f})",
+                 idx, dx, dy, dz, largest_dim, volume_cm3,
+                 obj.object.pose.position.x, obj.object.pose.position.y, obj.object.pose.position.z);
+
+    bool reject = false;
+    if (largest_dim > max_dim)
+    {
+      spdlog::warn("       -> REJECTED: largest dim {:.4f}m > max {:.3f}m", largest_dim, max_dim);
+      reject = true;
+    }
+    else if (max_vol > 0.0 && volume_cm3 > max_vol)
+    {
+      spdlog::warn("       -> REJECTED: volume {:.1f}cm3 > max {:.1f}cm3", volume_cm3, max_vol);
+      reject = true;
+    }
+    else
+    {
+      spdlog::warn("       -> ACCEPTED");
+    }
+
+    if (reject)
+    {
+      rejected.push_back(obj);
+    }
+    else
+    {
+      accepted.push_back(obj);
+    }
+    ++idx;
+  }
+
+  // Sort accepted by centroid Z height (highest first)
+  std::sort(accepted.begin(), accepted.end(),
+            [](const moveit_studio_vision_msgs::msg::GraspableObject& a,
+               const moveit_studio_vision_msgs::msg::GraspableObject& b) {
+              return a.object.pose.position.z > b.object.pose.position.z;
+            });
+
+  // Publish visualization markers
+  visualization_msgs::msg::MarkerArray marker_array;
+  int marker_id = 5000;
+
+  // Clear previous filter markers
+  visualization_msgs::msg::Marker delete_marker;
+  delete_marker.action = visualization_msgs::msg::Marker::DELETEALL;
+  delete_marker.ns = kMarkerNamespace;
+  marker_array.markers.push_back(delete_marker);
+
+  // Only show accepted objects (green transparent)
+  for (const auto& obj : accepted)
+  {
+    marker_array.markers.push_back(makeBoxMarker(obj, marker_id++, 0.2f, 1.0f, 0.4f, 0.4f));
+  }
+
+  marker_pub_->publish(marker_array);
+
+  spdlog::warn("=== FilterGraspableObjects: {} ACCEPTED, {} REJECTED ===", accepted.size(), rejected.size());
+
+  if (accepted.empty())
+  {
+    spdlog::warn("FilterGraspableObjects: NO objects passed the filter!");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  setOutput(kPortIDObjectsOut, accepted);
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace filter_graspable_objects

--- a/src/filter_graspable_objects/src/register_behaviors.cpp
+++ b/src/filter_graspable_objects/src/register_behaviors.cpp
@@ -1,0 +1,24 @@
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <filter_graspable_objects/filter_graspable_objects.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace filter_graspable_objects
+{
+class FilterGraspableObjectsBehaviorsLoader : public moveit_pro::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(BT::BehaviorTreeFactory& factory,
+    [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_pro::behaviors::registerBehavior<FilterGraspableObjects>(factory, "FilterGraspableObjects", shared_resources);
+    
+  }
+};
+}  // namespace filter_graspable_objects
+
+PLUGINLIB_EXPORT_CLASS(filter_graspable_objects::FilterGraspableObjectsBehaviorsLoader,
+                       moveit_pro::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/filter_graspable_objects/test/CMakeLists.txt
+++ b/src/filter_graspable_objects/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+
+ament_add_ros_isolated_gtest(test_behavior_plugins test_behavior_plugins.cpp)
+ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/filter_graspable_objects/test/test_behavior_plugins.cpp
+++ b/src/filter_graspable_objects/test/test_behavior_plugins.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/node.hpp>
+
+/**
+ * @brief This test makes sure that the Behaviors provided in this package can be successfully registered and
+ * instantiated by the behavior tree factory.
+ */
+TEST(BehaviorTests, test_load_behavior_plugins)
+{
+  pluginlib::ClassLoader<moveit_pro::behaviors::SharedResourcesNodeLoaderBase> class_loader(
+      "moveit_pro_behavior_interface", "moveit_pro::behaviors::SharedResourcesNodeLoaderBase");
+
+  auto node = std::make_shared<rclcpp::Node>("BehaviorTests");
+  auto shared_resources = std::make_shared<moveit_pro::behaviors::BehaviorContext>(node);
+
+  BT::BehaviorTreeFactory factory;
+  {
+    auto plugin_instance = class_loader.createUniqueInstance("filter_graspable_objects::FilterGraspableObjectsBehaviorsLoader");
+    ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
+  }
+
+  // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
+  EXPECT_NO_THROW(
+    (void)factory.instantiateTreeNode("test_behavior_name", "FilterGraspableObjects", BT::NodeConfiguration()));
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
New behavior plugin that filters detected objects to only those that are graspable based on max linear dimension. Gets rid of massive graspable objects due to obscured object detections. 