### PR TITLE
Add simplified best pick calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 This is a [MoveIt Pro](https://picknik.ai/pro) robot configuration for UR e-series robots.
 
 Refer to the [UR Hardware Setup Guide](https://docs.picknik.ai/hardware_guides/ur5e_hardware_setup_guide) for installation.
+
+### Build without hardware
+```
+moveit_pro build --colcon-args "--packages-ignore zed_ros2 zed_components zed_wrapper"
+
+# OR
+
+colcon build --packages-ignore zed_ros2 zed_components zed_wrapper
+```

--- a/SolidPrimitive
+++ b/SolidPrimitive
@@ -1,0 +1,56 @@
+# Defines box, sphere, cylinder, cone and prism.
+# All shapes are defined to have their bounding boxes centered around 0,0,0.
+
+uint8 BOX=1
+uint8 SPHERE=2
+uint8 CYLINDER=3
+uint8 CONE=4
+uint8 PRISM=5
+
+# The type of the shape
+uint8 type
+
+# The dimensions of the shape
+float64[<=3] dimensions  # At no point will dimensions have a length > 3.
+
+# The meaning of the shape dimensions: each constant defines the index in the 'dimensions' array.
+
+# For type BOX, the X, Y, and Z dimensions are the length of the corresponding sides of the box.
+uint8 BOX_X=0
+uint8 BOX_Y=1
+uint8 BOX_Z=2
+
+# For the SPHERE type, only one component is used, and it gives the radius of the sphere.
+uint8 SPHERE_RADIUS=0
+
+# For the CYLINDER and CONE types, the center line is oriented along the Z axis.
+# Therefore the CYLINDER_HEIGHT (CONE_HEIGHT) component of dimensions gives the
+# height of the cylinder (cone).
+# The CYLINDER_RADIUS (CONE_RADIUS) component of dimensions gives the radius of
+# the base of the cylinder (cone).
+# Cone and cylinder primitives are defined to be circular. The tip of the cone
+# is pointing up, along +Z axis.
+
+uint8 CYLINDER_HEIGHT=0
+uint8 CYLINDER_RADIUS=1
+
+uint8 CONE_HEIGHT=0
+uint8 CONE_RADIUS=1
+
+# For the type PRISM, the center line is oriented along Z axis.
+# The PRISM_HEIGHT component of dimensions gives the
+# height of the prism.
+# The polygon defines the Z axis centered base of the prism.
+# The prism is constructed by extruding the base in +Z and -Z
+# directions by half of the PRISM_HEIGHT
+# Only x and y fields of the points are used in the polygon.
+# Points of the polygon are ordered counter-clockwise.
+
+uint8 PRISM_HEIGHT=0
+geometry_msgs/Polygon polygon
+	Point32[] points
+		#
+		#
+		float32 x
+		float32 y
+		float32 z

--- a/src/picknik_009_ur5e_behaviors/CMakeLists.txt
+++ b/src/picknik_009_ur5e_behaviors/CMakeLists.txt
@@ -4,7 +4,7 @@ project(picknik_009_ur5e_behaviors CXX)
 find_package(moveit_pro_package REQUIRED)
 moveit_pro_package()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS geometry_msgs moveit_pro_behavior_interface pluginlib shape_msgs)
+set(THIS_PACKAGE_INCLUDE_DEPENDS geometry_msgs moveit_pro_behavior_interface pluginlib shape_msgs tf2_eigen)
 foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${package} REQUIRED)
 endforeach()
@@ -15,6 +15,7 @@ add_library(
   picknik_009_ur5e_behaviors
   SHARED
   src/create_solid_primitive_from_shape.cpp
+  src/generate_surface_poses_from_solid_primitive.cpp
   src/register_behaviors.cpp)
 target_include_directories(
   picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/CMakeLists.txt
+++ b/src/picknik_009_ur5e_behaviors/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.22)
+project(picknik_009_ur5e_behaviors CXX)
+
+find_package(moveit_pro_package REQUIRED)
+moveit_pro_package()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS geometry_msgs moveit_pro_behavior_interface pluginlib shape_msgs)
+foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${package} REQUIRED)
+endforeach()
+
+find_package(spdlog REQUIRED)
+
+add_library(
+  picknik_009_ur5e_behaviors
+  SHARED
+  src/create_solid_primitive_from_shape.cpp
+  src/register_behaviors.cpp)
+target_include_directories(
+  picknik_009_ur5e_behaviors
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(picknik_009_ur5e_behaviors
+                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(picknik_009_ur5e_behaviors spdlog::spdlog)
+
+install(
+  TARGETS picknik_009_ur5e_behaviors
+  EXPORT picknik_009_ur5e_behaviorsTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES
+  DESTINATION include)
+
+pluginlib_export_plugin_description_file(
+  moveit_pro_behavior_interface picknik_009_ur5e_behaviors_plugin_description.xml)
+
+ament_export_targets(picknik_009_ur5e_behaviorsTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/picknik_009_ur5e_behaviors/CMakeLists.txt
+++ b/src/picknik_009_ur5e_behaviors/CMakeLists.txt
@@ -4,18 +4,28 @@ project(picknik_009_ur5e_behaviors CXX)
 find_package(moveit_pro_package REQUIRED)
 moveit_pro_package()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS geometry_msgs moveit_pro_behavior_interface pluginlib shape_msgs tf2_eigen)
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+    ament_index_cpp
+    geometry_msgs
+    moveit_pro_behavior_interface
+    pluginlib
+    rclcpp
+    shape_msgs
+    tf2_eigen)
 foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${package} REQUIRED)
 endforeach()
 
 find_package(spdlog REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 add_library(
   picknik_009_ur5e_behaviors
   SHARED
   src/create_solid_primitive_from_shape.cpp
   src/generate_surface_poses_from_solid_primitive.cpp
+  src/read_yaml_list.cpp
+  src/read_yaml_value.cpp
   src/register_behaviors.cpp)
 target_include_directories(
   picknik_009_ur5e_behaviors
@@ -23,7 +33,7 @@ target_include_directories(
          $<INSTALL_INTERFACE:include>)
 ament_target_dependencies(picknik_009_ur5e_behaviors
                           ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_link_libraries(picknik_009_ur5e_behaviors spdlog::spdlog)
+target_link_libraries(picknik_009_ur5e_behaviors spdlog::spdlog yaml-cpp)
 
 install(
   TARGETS picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/behavior_plugin.yaml
+++ b/src/picknik_009_ur5e_behaviors/behavior_plugin.yaml
@@ -1,0 +1,4 @@
+objectives:
+  behavior_loader_plugins:
+    picknik_009_ur5e_behaviors:
+      - "picknik_009_ur5e_behaviors::Picknik009Ur5eBehaviorsLoader"

--- a/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/create_solid_primitive_from_shape.hpp
+++ b/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/create_solid_primitive_from_shape.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+
+#include <string>
+
+namespace picknik_009_ur5e_behaviors
+{
+
+class CreateSolidPrimitiveFromShape final : public BT::SyncActionNode
+{
+public:
+  CreateSolidPrimitiveFromShape(const std::string& name, const BT::NodeConfiguration& config);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/generate_surface_poses_from_solid_primitive.hpp
+++ b/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/generate_surface_poses_from_solid_primitive.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+
+#include <string>
+
+namespace picknik_009_ur5e_behaviors
+{
+
+class GenerateSurfacePosesFromSolidPrimitive final : public BT::SyncActionNode
+{
+public:
+  GenerateSurfacePosesFromSolidPrimitive(const std::string& name, const BT::NodeConfiguration& config);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/read_yaml_list.hpp
+++ b/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/read_yaml_list.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace picknik_009_ur5e_behaviors
+{
+/**
+ * @brief Reads a list from a YAML file as a vector of strings given a package name, relative file path, and nested keys.
+ * @details This behavior uses BT::SyncActionNode wrapped in SharedResourcesNode to read a YAML file
+ * and extract a list value from a nested key structure, converting all elements to strings.
+ */
+class ReadYamlList : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  /**
+   * @brief Constructor for ReadYamlList behavior.
+   * @param name The name of a particular instance of this Behavior.
+   * @param config Runtime configuration for this Behavior, including port mappings.
+   * @param shared_resources Shared resources provided by the behavior context.
+   */
+  ReadYamlList(const std::string& name, const BT::NodeConfiguration& config,
+               const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  /**
+   * @brief Implementation of the required providedPorts() function.
+   * @details Defines input and output ports for this behavior:
+   * - Input: package_name (string) - Name of the ROS2 package
+   * - Input: relative_file_path (string) - Relative path from package root to YAML file
+   * - Input: key1 (string) - First key (mandatory)
+   * - Input: key2 (string) - Second key (optional)
+   * - Input: key3 (string) - Third key (optional)
+   * - Input: key4 (string) - Fourth key (optional)
+   * - Input: key5 (string) - Fifth key (optional)
+   * - Output: value_list (vector<string>) - The extracted list as a vector of strings
+   * @return A BT::PortsList containing the behavior's ports.
+   */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying behavior information.
+   * @return A BT::KeyValueVector containing the behavior's metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+  /**
+   * @brief Implementation of BT::SyncActionNode::tick().
+   * @details Reads the YAML file, traverses the nested keys, and extracts the list as a vector of strings.
+   * All list elements are converted to strings regardless of their original type.
+   * This function completes synchronously.
+   * @return BT::NodeStatus::SUCCESS if list was successfully read, FAILURE otherwise.
+   */
+  BT::NodeStatus tick() override;
+};
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/read_yaml_value.hpp
+++ b/src/picknik_009_ur5e_behaviors/include/picknik_009_ur5e_behaviors/read_yaml_value.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace picknik_009_ur5e_behaviors
+{
+/**
+ * @brief Reads a value from a YAML file given a package name, relative file path, and nested keys.
+ * @details This behavior uses BT::SyncActionNode wrapped in SharedResourcesNode to read a YAML file
+ * and extract a string value from a nested key structure.
+ */
+class ReadYamlValue : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  /**
+   * @brief Constructor for ReadYamlValue behavior.
+   * @param name The name of a particular instance of this Behavior.
+   * @param config Runtime configuration for this Behavior, including port mappings.
+   * @param shared_resources Shared resources provided by the behavior context.
+   */
+  ReadYamlValue(const std::string& name, const BT::NodeConfiguration& config,
+                const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  /**
+   * @brief Implementation of the required providedPorts() function.
+   * @details Defines input and output ports for this behavior:
+   * - Input: package_name (string) - Name of the ROS2 package
+   * - Input: relative_file_path (string) - Relative path from package root to YAML file
+   * - Input: key1 (string) - First key (mandatory)
+   * - Input: key2 (string) - Second key (optional)
+   * - Input: key3 (string) - Third key (optional)
+   * - Input: key4 (string) - Fourth key (optional)
+   * - Output: value (string) - The extracted string value from the YAML file
+   * @return A BT::PortsList containing the behavior's ports.
+   */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying behavior information.
+   * @return A BT::KeyValueVector containing the behavior's metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+  /**
+   * @brief Implementation of BT::SyncActionNode::tick().
+   * @details Reads the YAML file, traverses the nested keys, and extracts the value.
+   * This function completes synchronously.
+   * @return BT::NodeStatus::SUCCESS if value was successfully read, FAILURE otherwise.
+   */
+  BT::NodeStatus tick() override;
+};
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/package.xml
+++ b/src/picknik_009_ur5e_behaviors/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package format="3">
+  <name>picknik_009_ur5e_behaviors</name>
+  <version>0.0.0</version>
+  <description>Custom behavior package scaffold for the PickNik 009 UR5e configuration.</description>
+
+  <maintainer email="support@picknik.ai">
+    MoveIt Pro User
+  </maintainer>
+  <author email="support@picknik.ai">
+    MoveIt Pro User
+  </author>
+
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_pro_package</build_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>moveit_pro_behavior_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>shape_msgs</depend>
+  <depend>spdlog</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+  <buildtool_depend>python3-colcon-common-extensions</buildtool_depend>
+</package>

--- a/src/picknik_009_ur5e_behaviors/package.xml
+++ b/src/picknik_009_ur5e_behaviors/package.xml
@@ -22,6 +22,7 @@
   <depend>pluginlib</depend>
   <depend>shape_msgs</depend>
   <depend>spdlog</depend>
+  <depend>tf2_eigen</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/picknik_009_ur5e_behaviors/picknik_009_ur5e_behaviors_plugin_description.xml
+++ b/src/picknik_009_ur5e_behaviors/picknik_009_ur5e_behaviors_plugin_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<library path="picknik_009_ur5e_behaviors">
+  <class
+    type="picknik_009_ur5e_behaviors::Picknik009Ur5eBehaviorsLoader"
+    base_class_type="moveit_pro::behaviors::SharedResourcesNodeLoaderBase"
+  />
+</library>

--- a/src/picknik_009_ur5e_behaviors/src/create_solid_primitive_from_shape.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/create_solid_primitive_from_shape.cpp
@@ -25,8 +25,8 @@ inline constexpr auto kDescription = R"(
         Supported shape types:
         <ul>
         <li><b>cube</b>: [x, y, z]</li>
-            <li><b>sphere</b>: [radius]</li>
-            <li><b>cylinder</b>: [radius, height]</li>
+          <li><b>sphere</b>: [radius, radius, radius]</li>
+          <li><b>cylinder</b>: [radius, radius, height]</li>
         </ul>
     </p>
 )";
@@ -62,8 +62,8 @@ BT::PortsList CreateSolidPrimitiveFromShape::providedPorts()
                                "Shape type to create: 'cube', 'sphere', or 'cylinder'."),
     BT::InputPort<std::vector<double>>(kPortIDDimensions, "{dimensions}",
                                        "Dimensions in meters. Expects a 3-element vector. "
-                                       "Cube uses [x;y;z], sphere uses the first element as [radius], "
-                                       "and cylinder uses the first two elements as [radius;height]."),
+                                       "Cube uses [x;y;z], sphere uses [radius;radius;radius], "
+                                       "and cylinder uses [radius;radius;height]."),
     BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped, "{pose_stamped}",
                                                    "Pose associated with the primitive."),
     BT::OutputPort<shape_msgs::msg::SolidPrimitive>(kPortIDSolidPrimitive, "{solid_primitive}",
@@ -108,29 +108,42 @@ BT::NodeStatus CreateSolidPrimitiveFromShape::tick()
     return BT::NodeStatus::FAILURE;
   }
 
-  if (!allPositive(dimensions))
-  {
-    spdlog::error("CreateSolidPrimitiveFromShape: all dimensions must be positive.");
-    return BT::NodeStatus::FAILURE;
-  }
-
   shape_msgs::msg::SolidPrimitive primitive;
 
   if (shape_type == "cube")
   {
+    if (!allPositive(dimensions))
+    {
+      spdlog::error("CreateSolidPrimitiveFromShape: cube dimensions [x, y, z] must all be positive.");
+      return BT::NodeStatus::FAILURE;
+    }
+
     primitive.type = shape_msgs::msg::SolidPrimitive::BOX;
     primitive.dimensions.assign(dimensions.begin(), dimensions.end());
   }
   else if (shape_type == "sphere")
   {
+    if (!allPositive(dimensions))
+    {
+      spdlog::error("CreateSolidPrimitiveFromShape: sphere dimensions [radius, radius, radius] must all be positive.");
+      return BT::NodeStatus::FAILURE;
+    }
+
     primitive.type = shape_msgs::msg::SolidPrimitive::SPHERE;
     primitive.dimensions = { dimensions[0] };
   }
   else if (shape_type == "cylinder")
   {
+    if (!allPositive(dimensions))
+    {
+      spdlog::error(
+          "CreateSolidPrimitiveFromShape: cylinder dimensions [radius, radius, height] must all be positive.");
+      return BT::NodeStatus::FAILURE;
+    }
+
     primitive.type = shape_msgs::msg::SolidPrimitive::CYLINDER;
     primitive.dimensions.resize(2);
-    primitive.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT] = dimensions[1];
+    primitive.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT] = dimensions[2];
     primitive.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS] = dimensions[0];
   }
   else

--- a/src/picknik_009_ur5e_behaviors/src/create_solid_primitive_from_shape.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/create_solid_primitive_from_shape.cpp
@@ -1,0 +1,148 @@
+#include <picknik_009_ur5e_behaviors/create_solid_primitive_from_shape.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <shape_msgs/msg/solid_primitive.hpp>
+#include <spdlog/spdlog.h>
+
+namespace
+{
+constexpr auto kPortIDShapeType = "shape_type";
+constexpr auto kPortIDDimensions = "dimensions";
+constexpr auto kPortIDPoseStamped = "pose_stamped";
+constexpr auto kPortIDSolidPrimitive = "solid_primitive";
+
+inline constexpr auto kDescription = R"(
+    <p>
+        Creates a <b>shape_msgs::msg::SolidPrimitive</b> from a primitive type,
+        a dimension vector, and a pose.
+    </p>
+    <p>
+        Supported shape types:
+        <ul>
+        <li><b>cube</b>: [x, y, z]</li>
+            <li><b>sphere</b>: [radius]</li>
+            <li><b>cylinder</b>: [radius, height]</li>
+        </ul>
+    </p>
+)";
+
+[[nodiscard]] bool allPositive(const std::vector<double>& dimensions)
+{
+  return std::ranges::all_of(dimensions, [](double dimension) { return dimension > 0.0; });
+}
+
+[[nodiscard]] std::string normalizeShapeType(std::string shape_type)
+{
+  std::transform(shape_type.begin(), shape_type.end(), shape_type.begin(), [](unsigned char character) {
+    return static_cast<char>(std::tolower(character));
+  });
+  return shape_type;
+}
+
+}  // namespace
+
+namespace picknik_009_ur5e_behaviors
+{
+
+CreateSolidPrimitiveFromShape::CreateSolidPrimitiveFromShape(const std::string& name,
+                                                             const BT::NodeConfiguration& config)
+  : BT::SyncActionNode(name, config)
+{
+}
+
+BT::PortsList CreateSolidPrimitiveFromShape::providedPorts()
+{
+  return {
+    BT::InputPort<std::string>(kPortIDShapeType, "{shape_type}",
+                               "Shape type to create: 'cube', 'sphere', or 'cylinder'."),
+    BT::InputPort<std::vector<double>>(kPortIDDimensions, "{dimensions}",
+                                       "Dimensions in meters. Expects a 3-element vector. "
+                                       "Cube uses [x;y;z], sphere uses the first element as [radius], "
+                                       "and cylinder uses the first two elements as [radius;height]."),
+    BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped, "{pose_stamped}",
+                                                   "Pose associated with the primitive."),
+    BT::OutputPort<shape_msgs::msg::SolidPrimitive>(kPortIDSolidPrimitive, "{solid_primitive}",
+                                                    "Constructed SolidPrimitive message."),
+  };
+}
+
+BT::KeyValueVector CreateSolidPrimitiveFromShape::metadata()
+{
+  return { { "subcategory", "Planning Scene" }, { "description", kDescription } };
+}
+
+BT::NodeStatus CreateSolidPrimitiveFromShape::tick()
+{
+  const auto shape_type_input = getInput<std::string>(kPortIDShapeType);
+  const auto dimensions_input = getInput<std::vector<double>>(kPortIDDimensions);
+  const auto pose_stamped_input = getInput<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped);
+
+  if (!shape_type_input.has_value())
+  {
+    spdlog::error("CreateSolidPrimitiveFromShape: failed to get 'shape_type' input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!dimensions_input.has_value())
+  {
+    spdlog::error("CreateSolidPrimitiveFromShape: failed to get 'dimensions' input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!pose_stamped_input.has_value())
+  {
+    spdlog::error("CreateSolidPrimitiveFromShape: failed to get 'pose_stamped' input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const std::string shape_type = normalizeShapeType(shape_type_input.value());
+  const auto& dimensions = dimensions_input.value();
+
+  if (dimensions.size() != 3)
+  {
+    spdlog::error("CreateSolidPrimitiveFromShape: 'dimensions' must contain exactly 3 elements, got {}.",
+                  dimensions.size());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (!allPositive(dimensions))
+  {
+    spdlog::error("CreateSolidPrimitiveFromShape: all dimensions must be positive.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  shape_msgs::msg::SolidPrimitive primitive;
+
+  if (shape_type == "cube")
+  {
+    primitive.type = shape_msgs::msg::SolidPrimitive::BOX;
+    primitive.dimensions.assign(dimensions.begin(), dimensions.end());
+  }
+  else if (shape_type == "sphere")
+  {
+    primitive.type = shape_msgs::msg::SolidPrimitive::SPHERE;
+    primitive.dimensions = { dimensions[0] };
+  }
+  else if (shape_type == "cylinder")
+  {
+    primitive.type = shape_msgs::msg::SolidPrimitive::CYLINDER;
+    primitive.dimensions.resize(2);
+    primitive.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT] = dimensions[1];
+    primitive.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS] = dimensions[0];
+  }
+  else
+  {
+    spdlog::error(
+        "CreateSolidPrimitiveFromShape: unsupported shape type '{}'. Must be 'cube', 'sphere', or 'cylinder'.",
+        shape_type_input.value());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  setOutput(kPortIDSolidPrimitive, primitive);
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/src/generate_surface_poses_from_solid_primitive.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/generate_surface_poses_from_solid_primitive.cpp
@@ -1,0 +1,332 @@
+#include <picknik_009_ur5e_behaviors/generate_surface_poses_from_solid_primitive.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <numbers>
+#include <string>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <shape_msgs/msg/solid_primitive.hpp>
+#include <spdlog/spdlog.h>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+namespace
+{
+constexpr auto kPortIDSolidPrimitive = "solid_primitive";
+constexpr auto kPortIDPrimitivePose = "primitive_pose";
+constexpr auto kPortIDAngularFaceResolution = "angular_face_resolution";
+constexpr auto kPortIDZOffset = "z_offset";
+constexpr auto kPortIDPoses = "poses";
+
+inline constexpr auto kDescription = R"(
+    <p>
+        Generates surface-aligned <b>geometry_msgs::msg::PoseStamped</b> samples for a
+        <b>shape_msgs::msg::SolidPrimitive</b>.
+    </p>
+    <p>
+        The primitive pose is required because <b>SolidPrimitive</b> does not carry frame information.
+        Generated poses are first built in the primitive local frame and then transformed into the
+        frame stored in <b>primitive_pose.header.frame_id</b>.
+    </p>
+    <p>
+        Sampling strategy:
+        <ul>
+            <li><b>box</b>: the 6 face centroids</li>
+            <li><b>sphere</b>: 3 great circles on the X=0, Y=0, and Z=0 planes</li>
+            <li><b>cylinder</b>: top and bottom face centroids plus samples around the curved surface at Z=0</li>
+        </ul>
+    </p>
+    <p>
+        Each pose is oriented so its local +Z axis points toward the primitive centroid, then translated
+        by <b>z_offset</b> along local -Z to back away from the surface.
+    </p>
+)";
+
+constexpr double kAxisParallelThreshold = 0.9;
+constexpr double kDuplicateTolerance = 1e-9;
+
+[[nodiscard]] double degToRad(const double degrees)
+{
+  return degrees * std::numbers::pi_v<double> / 180.0;
+}
+
+[[nodiscard]] Eigen::Vector3d chooseReferenceAxis(const Eigen::Vector3d& z_axis)
+{
+  if (std::abs(z_axis.dot(Eigen::Vector3d::UnitZ())) < kAxisParallelThreshold)
+  {
+    return Eigen::Vector3d::UnitZ();
+  }
+  if (std::abs(z_axis.dot(Eigen::Vector3d::UnitY())) < kAxisParallelThreshold)
+  {
+    return Eigen::Vector3d::UnitY();
+  }
+  return Eigen::Vector3d::UnitX();
+}
+
+[[nodiscard]] Eigen::Quaterniond orientationTowardCentroid(const Eigen::Vector3d& surface_point)
+{
+  const Eigen::Vector3d z_axis = (-surface_point).normalized();
+  const Eigen::Vector3d reference_axis = chooseReferenceAxis(z_axis);
+  const Eigen::Vector3d x_axis = reference_axis.cross(z_axis).normalized();
+  const Eigen::Vector3d y_axis = z_axis.cross(x_axis).normalized();
+
+  Eigen::Matrix3d rotation;
+  rotation.col(0) = x_axis;
+  rotation.col(1) = y_axis;
+  rotation.col(2) = z_axis;
+  return Eigen::Quaterniond(rotation);
+}
+
+void appendUniquePoint(std::vector<Eigen::Vector3d>& points, const Eigen::Vector3d& candidate)
+{
+  const auto duplicate = std::ranges::any_of(points, [&](const Eigen::Vector3d& point) {
+    return (point - candidate).norm() <= kDuplicateTolerance;
+  });
+
+  if (!duplicate)
+  {
+    points.push_back(candidate);
+  }
+}
+
+[[nodiscard]] std::vector<Eigen::Vector3d> sampleCirclePoints(
+    const std::function<Eigen::Vector3d(double)>& point_generator,
+    const double angular_resolution_deg)
+{
+  std::vector<Eigen::Vector3d> points;
+
+  for (double angle_deg = 0.0; angle_deg < 360.0; angle_deg += angular_resolution_deg)
+  {
+    appendUniquePoint(points, point_generator(degToRad(angle_deg)));
+  }
+
+  return points;
+}
+
+[[nodiscard]] bool dimensionsValid(const shape_msgs::msg::SolidPrimitive& primitive)
+{
+  switch (primitive.type)
+  {
+    case shape_msgs::msg::SolidPrimitive::BOX:
+      return primitive.dimensions.size() >= 3;
+    case shape_msgs::msg::SolidPrimitive::SPHERE:
+      return !primitive.dimensions.empty();
+    case shape_msgs::msg::SolidPrimitive::CYLINDER:
+      return primitive.dimensions.size() >= 2;
+    default:
+      return false;
+  }
+}
+
+[[nodiscard]] bool dimensionsPositive(const shape_msgs::msg::SolidPrimitive& primitive)
+{
+  return std::ranges::all_of(primitive.dimensions, [](const double dimension) { return dimension > 0.0; });
+}
+
+[[nodiscard]] std::vector<Eigen::Vector3d> sampleSurfacePoints(
+    const shape_msgs::msg::SolidPrimitive& primitive,
+    const double angular_resolution_deg)
+{
+  std::vector<Eigen::Vector3d> points;
+
+  switch (primitive.type)
+  {
+    case shape_msgs::msg::SolidPrimitive::BOX:
+    {
+      const double half_x = primitive.dimensions[shape_msgs::msg::SolidPrimitive::BOX_X] * 0.5;
+      const double half_y = primitive.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Y] * 0.5;
+      const double half_z = primitive.dimensions[shape_msgs::msg::SolidPrimitive::BOX_Z] * 0.5;
+      points = {
+        Eigen::Vector3d(half_x, 0.0, 0.0),
+        Eigen::Vector3d(-half_x, 0.0, 0.0),
+        Eigen::Vector3d(0.0, half_y, 0.0),
+        Eigen::Vector3d(0.0, -half_y, 0.0),
+        Eigen::Vector3d(0.0, 0.0, half_z),
+        Eigen::Vector3d(0.0, 0.0, -half_z),
+      };
+      break;
+    }
+    case shape_msgs::msg::SolidPrimitive::SPHERE:
+    {
+      const double radius = primitive.dimensions[shape_msgs::msg::SolidPrimitive::SPHERE_RADIUS];
+      for (const auto& circle_points : {
+               sampleCirclePoints([&](const double angle_rad) {
+                 return Eigen::Vector3d(0.0, radius * std::cos(angle_rad), radius * std::sin(angle_rad));
+               }, angular_resolution_deg),
+               sampleCirclePoints([&](const double angle_rad) {
+                 return Eigen::Vector3d(radius * std::cos(angle_rad), 0.0, radius * std::sin(angle_rad));
+               }, angular_resolution_deg),
+               sampleCirclePoints([&](const double angle_rad) {
+                 return Eigen::Vector3d(radius * std::cos(angle_rad), radius * std::sin(angle_rad), 0.0);
+               }, angular_resolution_deg) })
+      {
+        for (const auto& point : circle_points)
+        {
+          appendUniquePoint(points, point);
+        }
+      }
+      break;
+    }
+    case shape_msgs::msg::SolidPrimitive::CYLINDER:
+    {
+      const double height = primitive.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_HEIGHT];
+      const double radius = primitive.dimensions[shape_msgs::msg::SolidPrimitive::CYLINDER_RADIUS];
+      points = {
+        Eigen::Vector3d(0.0, 0.0, height * 0.5),
+        Eigen::Vector3d(0.0, 0.0, -height * 0.5),
+      };
+
+      for (const auto& point : sampleCirclePoints(
+               [&](const double angle_rad) {
+                 return Eigen::Vector3d(radius * std::cos(angle_rad), radius * std::sin(angle_rad), 0.0);
+               },
+               angular_resolution_deg))
+      {
+        appendUniquePoint(points, point);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return points;
+}
+
+}  // namespace
+
+namespace picknik_009_ur5e_behaviors
+{
+
+GenerateSurfacePosesFromSolidPrimitive::GenerateSurfacePosesFromSolidPrimitive(
+    const std::string& name,
+    const BT::NodeConfiguration& config)
+  : BT::SyncActionNode(name, config)
+{
+}
+
+BT::PortsList GenerateSurfacePosesFromSolidPrimitive::providedPorts()
+{
+  return {
+    BT::InputPort<shape_msgs::msg::SolidPrimitive>(kPortIDSolidPrimitive, "{solid_primitive}",
+                                                   "Primitive to sample."),
+    BT::InputPort<geometry_msgs::msg::PoseStamped>(
+        kPortIDPrimitivePose, "{primitive_pose}",
+        "Pose of the primitive frame in the output frame. Required because SolidPrimitive has no header."),
+    BT::InputPort<double>(kPortIDAngularFaceResolution, "{angular_face_resolution}",
+                          "Angular resolution in degrees for sphere and cylinder surface sampling."),
+    BT::InputPort<double>(kPortIDZOffset, "{z_offset}",
+                          "Offset applied along local -Z after orienting poses toward the centroid."),
+    BT::OutputPort<std::vector<geometry_msgs::msg::PoseStamped>>(kPortIDPoses, "{poses}",
+                                                                 "Generated surface poses."),
+  };
+}
+
+BT::KeyValueVector GenerateSurfacePosesFromSolidPrimitive::metadata()
+{
+  return { { "subcategory", "Planning Scene" }, { "description", kDescription } };
+}
+
+BT::NodeStatus GenerateSurfacePosesFromSolidPrimitive::tick()
+{
+  const auto primitive_input = getInput<shape_msgs::msg::SolidPrimitive>(kPortIDSolidPrimitive);
+  const auto primitive_pose_input = getInput<geometry_msgs::msg::PoseStamped>(kPortIDPrimitivePose);
+  const auto angular_resolution_input = getInput<double>(kPortIDAngularFaceResolution);
+  const auto z_offset_input = getInput<double>(kPortIDZOffset);
+
+  if (!primitive_input.has_value())
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: failed to get 'solid_primitive' input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!primitive_pose_input.has_value())
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: failed to get 'primitive_pose' input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!angular_resolution_input.has_value())
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: failed to get 'angular_face_resolution' input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!z_offset_input.has_value())
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: failed to get 'z_offset' input port.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto& primitive = primitive_input.value();
+  const auto& primitive_pose = primitive_pose_input.value();
+  const double angular_resolution_deg = angular_resolution_input.value();
+  const double z_offset = z_offset_input.value();
+
+  if (primitive_pose.header.frame_id.empty())
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: 'primitive_pose.header.frame_id' must not be empty.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (angular_resolution_deg <= 0.0)
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: 'angular_face_resolution' must be > 0.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (!dimensionsValid(primitive))
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: primitive dimensions are invalid for type {}.",
+                  primitive.type);
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (!dimensionsPositive(primitive))
+  {
+    spdlog::error("GenerateSurfacePosesFromSolidPrimitive: primitive dimensions must all be positive.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (primitive.type != shape_msgs::msg::SolidPrimitive::BOX &&
+      primitive.type != shape_msgs::msg::SolidPrimitive::SPHERE &&
+      primitive.type != shape_msgs::msg::SolidPrimitive::CYLINDER)
+  {
+    spdlog::error(
+        "GenerateSurfacePosesFromSolidPrimitive: unsupported primitive type {}. Only BOX, SPHERE, and CYLINDER are supported.",
+        primitive.type);
+    return BT::NodeStatus::FAILURE;
+  }
+
+  Eigen::Isometry3d primitive_transform = Eigen::Isometry3d::Identity();
+  tf2::fromMsg(primitive_pose.pose, primitive_transform);
+  const Eigen::Quaterniond primitive_rotation(primitive_transform.rotation());
+
+  const auto surface_points = sampleSurfacePoints(primitive, angular_resolution_deg);
+  std::vector<geometry_msgs::msg::PoseStamped> poses;
+  poses.reserve(surface_points.size());
+
+  for (const auto& surface_point : surface_points)
+  {
+    const Eigen::Quaterniond local_orientation = orientationTowardCentroid(surface_point);
+    const Eigen::Vector3d local_negative_z = local_orientation * Eigen::Vector3d::UnitZ();
+    const Eigen::Vector3d backed_off_local_position =
+      surface_point - (z_offset * local_negative_z);
+    const Eigen::Vector3d world_position = primitive_transform * backed_off_local_position;
+    const Eigen::Quaterniond world_orientation = primitive_rotation * local_orientation;
+
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header = primitive_pose.header;
+    pose.pose.position.x = world_position.x();
+    pose.pose.position.y = world_position.y();
+    pose.pose.position.z = world_position.z();
+    pose.pose.orientation = tf2::toMsg(world_orientation.normalized());
+    poses.push_back(pose);
+  }
+
+  setOutput(kPortIDPoses, poses);
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/src/read_yaml_list.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/read_yaml_list.cpp
@@ -1,0 +1,205 @@
+#include <picknik_009_ur5e_behaviors/read_yaml_list.hpp>
+
+#include <yaml-cpp/yaml.h>
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <filesystem>
+#include <fstream>
+#include <rclcpp/rclcpp.hpp>
+
+namespace picknik_009_ur5e_behaviors
+{
+ReadYamlList::ReadYamlList(const std::string& name, const BT::NodeConfiguration& config,
+                           const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList ReadYamlList::providedPorts()
+{
+  return { BT::InputPort<std::string>("package_name", "Name of the ROS2 package containing the YAML file"),
+           BT::InputPort<std::string>("relative_file_path", "Relative path from the package root to the YAML file"),
+           BT::InputPort<std::string>("key1", "First key to traverse YAML structure (mandatory)"),
+           BT::InputPort<std::string>("key2", "", "Second key to traverse YAML structure (optional)"),
+           BT::InputPort<std::string>("key3", "", "Third key to traverse YAML structure (optional)"),
+           BT::InputPort<std::string>("key4", "", "Fourth key to traverse YAML structure (optional)"),
+           BT::InputPort<std::string>("key5", "", "Fifth key to traverse YAML structure (optional)"),
+           BT::OutputPort<std::vector<std::string>>("value_list", "The extracted list as a vector of strings") };
+}
+
+BT::KeyValueVector ReadYamlList::metadata()
+{
+  return { { "description", "Reads a list from a YAML file as a vector of strings using nested keys" },
+           { "subcategory", "YAML Operations" } };
+}
+
+BT::NodeStatus ReadYamlList::tick()
+{
+  // Get input port values
+  auto package_name_result = getInput<std::string>("package_name");
+  auto relative_file_path_result = getInput<std::string>("relative_file_path");
+  auto key1_result = getInput<std::string>("key1");
+
+  // Validate inputs
+  if (!package_name_result)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to get 'package_name' from input port: %s",
+                 package_name_result.error().c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (!relative_file_path_result)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to get 'relative_file_path' from input port: %s",
+                 relative_file_path_result.error().c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (!key1_result)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to get 'key1' from input port: %s",
+                 key1_result.error().c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const std::string& package_name = package_name_result.value();
+  const std::string& relative_file_path = relative_file_path_result.value();
+
+  // Build keys vector from individual key ports
+  std::vector<std::string> keys;
+  keys.push_back(key1_result.value());
+
+  // Add optional keys if they are provided
+  auto key2_result = getInput<std::string>("key2");
+  if (key2_result && !key2_result.value().empty())
+  {
+    keys.push_back(key2_result.value());
+  }
+
+  auto key3_result = getInput<std::string>("key3");
+  if (key3_result && !key3_result.value().empty())
+  {
+    keys.push_back(key3_result.value());
+  }
+
+  auto key4_result = getInput<std::string>("key4");
+  if (key4_result && !key4_result.value().empty())
+  {
+    keys.push_back(key4_result.value());
+  }
+
+  auto key5_result = getInput<std::string>("key5");
+  if (key5_result && !key5_result.value().empty())
+  {
+    keys.push_back(key5_result.value());
+  }
+
+  // Resolve the full file path
+  std::string full_file_path;
+  try
+  {
+    std::string package_share_dir = ament_index_cpp::get_package_share_directory(package_name);
+    full_file_path = package_share_dir + "/" + relative_file_path;
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to find package '%s': %s", package_name.c_str(),
+                 e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Check if file exists
+  if (!std::filesystem::exists(full_file_path))
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "YAML file does not exist: %s", full_file_path.c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Load the YAML file
+  YAML::Node yaml_root;
+  try
+  {
+    yaml_root = YAML::LoadFile(full_file_path);
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to parse YAML file '%s': %s", full_file_path.c_str(),
+                 e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Traverse the YAML structure using the keys
+  YAML::Node current_node = yaml_root;
+  for (size_t i = 0; i < keys.size(); ++i)
+  {
+    const std::string& key = keys[i];
+
+    if (!current_node.IsDefined())
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "YAML node is undefined at key '%s'", key.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+
+    if (!current_node.IsMap())
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "YAML node at key '%s' is not a map", key.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+
+    if (!current_node[key])
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "Key '%s' not found in YAML file", key.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+
+    current_node = current_node[key];
+  }
+
+  // Extract the final value as a list
+  std::vector<std::string> value_list;
+  try
+  {
+    if (!current_node.IsSequence())
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "The final YAML node is not a sequence/list");
+      return BT::NodeStatus::FAILURE;
+    }
+
+    // Convert all elements to strings
+    for (std::size_t i = 0; i < current_node.size(); ++i)
+    {
+      const YAML::Node& element = current_node[i];
+
+      if (element.IsScalar())
+      {
+        // Convert scalar values (string, int, float, bool) to string
+        value_list.push_back(element.as<std::string>());
+      }
+      else
+      {
+        RCLCPP_WARN(shared_resources_->node->get_logger(), "List element at index %zu is not a scalar value, skipping",
+                    i);
+      }
+    }
+
+    if (value_list.empty())
+    {
+      RCLCPP_WARN(shared_resources_->node->get_logger(), "The list is empty or contains no scalar values");
+    }
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to convert YAML list to vector of strings: %s",
+                 e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Set the output port
+  setOutput("value_list", value_list);
+
+  RCLCPP_INFO(shared_resources_->node->get_logger(), "Successfully read list with %zu elements from YAML file: %s",
+              value_list.size(), full_file_path.c_str());
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/src/read_yaml_value.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/read_yaml_value.cpp
@@ -1,0 +1,186 @@
+#include <picknik_009_ur5e_behaviors/read_yaml_value.hpp>
+
+#include <yaml-cpp/yaml.h>
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <filesystem>
+#include <fstream>
+#include <rclcpp/rclcpp.hpp>
+
+namespace picknik_009_ur5e_behaviors
+{
+ReadYamlValue::ReadYamlValue(const std::string& name, const BT::NodeConfiguration& config,
+                             const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList ReadYamlValue::providedPorts()
+{
+  return { BT::InputPort<std::string>("package_name", "Name of the ROS2 package containing the YAML file"),
+           BT::InputPort<std::string>("relative_file_path", "Relative path from the package root to the YAML file"),
+           BT::InputPort<std::string>("key1", "First key to traverse YAML structure (mandatory)"),
+           BT::InputPort<std::string>("key2", "", "Second key to traverse YAML structure (optional)"),
+           BT::InputPort<std::string>("key3", "", "Third key to traverse YAML structure (optional)"),
+           BT::InputPort<std::string>("key4", "", "Fourth key to traverse YAML structure (optional)"),
+           BT::InputPort<std::string>("key5", "", "Fifth key to traverse YAML structure (optional)"),
+           BT::OutputPort<std::string>("value", "The extracted string value from the YAML file") };
+}
+
+BT::KeyValueVector ReadYamlValue::metadata()
+{
+  return { { "description", "Reads a string value from a YAML file using nested keys" },
+           { "subcategory", "YAML Operations" } };
+}
+
+BT::NodeStatus ReadYamlValue::tick()
+{
+  // Get input port values
+  auto package_name_result = getInput<std::string>("package_name");
+  auto relative_file_path_result = getInput<std::string>("relative_file_path");
+  auto key1_result = getInput<std::string>("key1");
+
+  // Validate inputs
+  if (!package_name_result)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to get 'package_name' from input port: %s",
+                 package_name_result.error().c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (!relative_file_path_result)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to get 'relative_file_path' from input port: %s",
+                 relative_file_path_result.error().c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  if (!key1_result)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to get 'key1' from input port: %s",
+                 key1_result.error().c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const std::string& package_name = package_name_result.value();
+  const std::string& relative_file_path = relative_file_path_result.value();
+
+  // Build keys vector from individual key ports
+  std::vector<std::string> keys;
+  keys.push_back(key1_result.value());
+
+  // Add optional keys if they are provided
+  auto key2_result = getInput<std::string>("key2");
+  if (key2_result && !key2_result.value().empty())
+  {
+    keys.push_back(key2_result.value());
+  }
+
+  auto key3_result = getInput<std::string>("key3");
+  if (key3_result && !key3_result.value().empty())
+  {
+    keys.push_back(key3_result.value());
+  }
+
+  auto key4_result = getInput<std::string>("key4");
+  if (key4_result && !key4_result.value().empty())
+  {
+    keys.push_back(key4_result.value());
+  }
+
+  auto key5_result = getInput<std::string>("key5");
+  if (key5_result && !key5_result.value().empty())
+  {
+    keys.push_back(key5_result.value());
+  }
+
+  // Resolve the full file path
+  std::string full_file_path;
+  try
+  {
+    std::string package_share_dir = ament_index_cpp::get_package_share_directory(package_name);
+    full_file_path = package_share_dir + "/" + relative_file_path;
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to find package '%s': %s", package_name.c_str(),
+                 e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Check if file exists
+  if (!std::filesystem::exists(full_file_path))
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "YAML file does not exist: %s", full_file_path.c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Load the YAML file
+  YAML::Node yaml_root;
+  try
+  {
+    yaml_root = YAML::LoadFile(full_file_path);
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to parse YAML file '%s': %s", full_file_path.c_str(),
+                 e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Traverse the YAML structure using the keys
+  YAML::Node current_node = yaml_root;
+  for (size_t i = 0; i < keys.size(); ++i)
+  {
+    const std::string& key = keys[i];
+
+    if (!current_node.IsDefined())
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "YAML node is undefined at key '%s'", key.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+
+    if (!current_node.IsMap())
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "YAML node at key '%s' is not a map", key.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+
+    if (!current_node[key])
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "Key '%s' not found in YAML file", key.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+
+    current_node = current_node[key];
+  }
+
+  // Extract the final value as a string
+  std::string value;
+  try
+  {
+    if (current_node.IsScalar())
+    {
+      value = current_node.as<std::string>();
+    }
+    else
+    {
+      RCLCPP_ERROR(shared_resources_->node->get_logger(), "The final YAML node is not a scalar value");
+      return BT::NodeStatus::FAILURE;
+    }
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(shared_resources_->node->get_logger(), "Failed to convert YAML value to string: %s", e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Set the output port
+  setOutput("value", value);
+
+  RCLCPP_INFO(shared_resources_->node->get_logger(), "Successfully read value '%s' from YAML file: %s", value.c_str(),
+              full_file_path.c_str());
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/src/register_behaviors.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/register_behaviors.cpp
@@ -1,0 +1,24 @@
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <picknik_009_ur5e_behaviors/create_solid_primitive_from_shape.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace picknik_009_ur5e_behaviors
+{
+class Picknik009Ur5eBehaviorsLoader : public moveit_pro::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(
+      BT::BehaviorTreeFactory& factory,
+      [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_pro::behaviors::registerBehavior<CreateSolidPrimitiveFromShape>(factory, "CreateSolidPrimitiveFromShape");
+  }
+};
+}  // namespace picknik_009_ur5e_behaviors
+
+PLUGINLIB_EXPORT_CLASS(picknik_009_ur5e_behaviors::Picknik009Ur5eBehaviorsLoader,
+                       moveit_pro::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/picknik_009_ur5e_behaviors/src/register_behaviors.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/register_behaviors.cpp
@@ -4,6 +4,8 @@
 
 #include <picknik_009_ur5e_behaviors/create_solid_primitive_from_shape.hpp>
 #include <picknik_009_ur5e_behaviors/generate_surface_poses_from_solid_primitive.hpp>
+#include <picknik_009_ur5e_behaviors/read_yaml_list.hpp>
+#include <picknik_009_ur5e_behaviors/read_yaml_value.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
 
@@ -19,6 +21,10 @@ public:
     moveit_pro::behaviors::registerBehavior<CreateSolidPrimitiveFromShape>(factory, "CreateSolidPrimitiveFromShape");
     moveit_pro::behaviors::registerBehavior<GenerateSurfacePosesFromSolidPrimitive>(
         factory, "GenerateSurfacePosesFromSolidPrimitive");
+    moveit_pro::behaviors::registerBehavior<picknik_009_ur5e_behaviors::ReadYamlList>(factory, "ReadYamlList",
+                                                                                        shared_resources);
+    moveit_pro::behaviors::registerBehavior<picknik_009_ur5e_behaviors::ReadYamlValue>(factory, "ReadYamlValue",
+                                                                                         shared_resources);
   }
 };
 }  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_behaviors/src/register_behaviors.cpp
+++ b/src/picknik_009_ur5e_behaviors/src/register_behaviors.cpp
@@ -3,6 +3,7 @@
 #include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
 
 #include <picknik_009_ur5e_behaviors/create_solid_primitive_from_shape.hpp>
+#include <picknik_009_ur5e_behaviors/generate_surface_poses_from_solid_primitive.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
 
@@ -16,6 +17,8 @@ public:
       [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
   {
     moveit_pro::behaviors::registerBehavior<CreateSolidPrimitiveFromShape>(factory, "CreateSolidPrimitiveFromShape");
+    moveit_pro::behaviors::registerBehavior<GenerateSurfacePosesFromSolidPrimitive>(
+        factory, "GenerateSurfacePosesFromSolidPrimitive");
   }
 };
 }  // namespace picknik_009_ur5e_behaviors

--- a/src/picknik_009_ur5e_config_mock_hw/config/bin_layouts.yaml
+++ b/src/picknik_009_ur5e_config_mock_hw/config/bin_layouts.yaml
@@ -1,0 +1,35 @@
+bin_layouts:
+  - layout_1
+
+# Each layout contains:
+
+# primitive_names: A list of primitive names included in the layout.
+# For each primitive:
+# type: The type of the primitive (e.g., cube, cylinder, sphere).
+# dimensions: The dimensions of the primitive 
+#             (e.g., length;width;height for cube, radius;radius;height for cylinder, radius;radius;radius for sphere).
+#             cylinder: double values for radius are required to maintain compatibility with the PublisherMarkers Behavior
+#             sphere: double values for radius are required to maintain compatibility with the PublisherMarkers Behavior
+# position: The position of the primitive in the bin (x;y;z). (wrt to world frame)
+# orientation: The orientation of the primitive in quaternion format (x;y;z;w). (wrt to world frame)
+layout_1:
+
+  primitive_names:
+    - cube_1
+    - cylinder_1
+    - sphere_1
+  cube_1:
+    type: cube
+    dimensions: 0.1;0.1;0.1
+    position: 1.0;0.5;0.0
+    orientation: 0.0;0.0;0.0;1.0
+  cylinder_1:
+    type: cylinder
+    dimensions: 0.1;0.1;0.1
+    position: 1.0;-0.5;0.0
+    orientation: 0.0;0.0;0.0;1.0
+  sphere_1:
+    type: sphere
+    dimensions: 0.1;0.1;0.1
+    position: 1.0;0.0;0.0
+    orientation: 0.0;0.0;0.0;1.0

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/find_best_pick.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/find_best_pick.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Find Best Pick">
+  <!--//////////-->
+  <BehaviorTree
+    ID="Find Best Pick"
+    _description="Simplified objective to select one solid primitive from a list that would be the best pick"
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <SubTree
+        ID="Generate Bin Objects"
+        _collapsed="true"
+        primitives="{primitives}"
+        primitive_poses="{primitive_poses}"
+      />
+      <Action ID="ResetVector" vector="{surface_poses_vector}" />
+      <Decorator
+        ID="ForEach"
+        name="Generate poses and add to a vector"
+        vector_in="{primitives}"
+        out="{primitive}"
+        index="{index}"
+      >
+        <Control ID="Sequence">
+          <Action
+            ID="GetElementOfVector"
+            element="{primitive_pose}"
+            vector_in="{primitive_poses}"
+            index="{index}"
+          />
+          <Action
+            ID="GenerateSurfacePosesFromSolidPrimitive"
+            solid_primitive="{primitive}"
+            primitive_pose="{primitive_pose}"
+            angular_face_resolution="45.0"
+            z_offset="0.05"
+            poses="{surface_poses}"
+          />
+          <Action
+            ID="VisualizePath"
+            path="{surface_poses}"
+            show_poses="true"
+            name="repurpose to display poses"
+          />
+          <Decorator ID="ForEach" vector_in="{surface_poses}" out="{surface_pose}">
+            <Action
+              ID="PushBackVector"
+              element="{surface_pose}"
+              input_vector="{surface_poses_vector}"
+              output_vector="{surface_poses_vector}"
+            />
+          </Decorator>
+          <Action ID="BreakpointSubscriber" />
+        </Control>
+      </Decorator>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Find Best Pick">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Grasping" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/find_best_pick.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/find_best_pick.xml
@@ -1,32 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Find Best Pick">
-  <!--//////////-->
   <BehaviorTree
     ID="Find Best Pick"
     _description="Simplified objective to select one solid primitive from a list that would be the best pick"
     _favorite="false"
   >
     <Control ID="Sequence" name="TopLevelSequence">
-      <SubTree
-        ID="Generate Bin Objects"
-        _collapsed="true"
-        primitives="{primitives}"
-        primitive_poses="{primitive_poses}"
-      />
-      <Action ID="ResetVector" vector="{surface_poses_vector}" />
+      <Action ID="Script" code="highest_pose_index:=-1" />
+      <Action ID="Script" code="highest_z_coord:=-100" />
       <Decorator
         ID="ForEach"
         name="Generate poses and add to a vector"
         vector_in="{primitives}"
         out="{primitive}"
-        index="{index}"
+        index="{index1}"
       >
         <Control ID="Sequence">
           <Action
             ID="GetElementOfVector"
             element="{primitive_pose}"
             vector_in="{primitive_poses}"
-            index="{index}"
+            index="{index1}"
           />
           <Action
             ID="GenerateSurfacePosesFromSolidPrimitive"
@@ -37,30 +31,127 @@
             poses="{surface_poses}"
           />
           <Action
+            ID="SolveIKQueries"
+            check_collisions="true"
+            joint_group_name="manipulator"
+            target_poses="{surface_poses}"
+            timeout="0.01"
+            ik_query_results="{ik_query_results}"
+          />
+          <Action ID="ResetVector" vector="{reachable_poses}" />
+          <Decorator
+            ID="ForEach"
+            out="{pose}"
+            vector_in="{surface_poses}"
+            index="{index2}"
+          >
+            <Control ID="Sequence">
+              <Action
+                ID="GetElementOfVector"
+                index="{index2}"
+                vector_in="{ik_query_results}"
+                element="{result}"
+              />
+              <Decorator ID="Precondition" else="SUCCESS" if="result">
+                <Control ID="Sequence">
+                  <SubTree
+                    ID="AddToVector"
+                    _collapsed="true"
+                    element="{pose}"
+                    input_vector="{reachable_poses}"
+                    output_vector="{reachable_poses}"
+                  />
+                  <Control ID="Sequence" name="find the z coord of the pose">
+                    <Action
+                      ID="UnpackPoseStampedMessage"
+                      header="{_header}"
+                      pose="{_pose}"
+                      pose_stamped="{pose}"
+                    />
+                    <Action
+                      ID="UnpackPoseMessage"
+                      orientation="{_orientation}"
+                      pose="{_pose}"
+                      position="{_position}"
+                    />
+                    <Action
+                      ID="UnpackPointMessage"
+                      point="{_position}"
+                      x="{_x}"
+                      y="{_y}"
+                      z="{z}"
+                    />
+                  </Control>
+                  <Decorator
+                    ID="Precondition"
+                    else="SUCCESS"
+                    if="highest_z_coord &lt; z"
+                  >
+                    <Control ID="Sequence">
+                      <Action ID="Script" code="highest_pose_index := index2" />
+                      <Action ID="Script" code="highest_z_coord := z" />
+                      <Action
+                        ID="GetElementOfVector"
+                        vector_in="{primitive_names}"
+                        element="{best_pick_primitive_name}"
+                        index="{index1}"
+                      />
+                      <Action
+                        ID="GetElementOfVector"
+                        vector_in="{primitives}"
+                        element="{best_pick_primitive}"
+                        index="{index1}"
+                      />
+                      <Action
+                        ID="GetElementOfVector"
+                        vector_in="{surface_poses}"
+                        element="{best_pick_pose}"
+                        index="{index2}"
+                      />
+                      <Action
+                        ID="GetElementOfVector"
+                        vector_in="{surface_poses}"
+                        element="{best_pick_pose}"
+                        index="{index2}"
+                      />
+                    </Control>
+                  </Decorator>
+                </Control>
+              </Decorator>
+            </Control>
+          </Decorator>
+          <Action
             ID="VisualizePath"
-            path="{surface_poses}"
+            path="{reachable_poses}"
             show_poses="true"
             name="repurpose to display poses"
+            marker_lifetime="0.0"
+            _skipIf="true"
           />
-          <Decorator ID="ForEach" vector_in="{surface_poses}" out="{surface_pose}">
-            <Action
-              ID="PushBackVector"
-              element="{surface_pose}"
-              input_vector="{surface_poses_vector}"
-              output_vector="{surface_poses_vector}"
-            />
-          </Decorator>
-          <Action ID="BreakpointSubscriber" />
         </Control>
+      </Decorator>
+      <Decorator ID="Precondition" if="highest_pose_index != -1">
+        <Action
+          ID="VisualizePose"
+          marker_name="best_pick_pose"
+          marker_size="0.25"
+          marker_text="best_pick_pose"
+          pose="{best_pick_pose}"
+        />
       </Decorator>
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Find Best Pick">
-      <MetadataFields>
-        <Metadata runnable="true" />
-        <Metadata subcategory="Grasping" />
-      </MetadataFields>
+      <output_port name="best_pick_pose" default="{best_pick_pose}" />
+      <output_port name="best_pick_primitive" default="{best_pick_primitive}" />
+      <output_port
+        name="best_pick_primitive_name"
+        default="{best_pick_primitive_name}"
+      />
+      <input_port name="primitive_names" default="{primitive_names}" />
+      <input_port name="primitive_poses" default="{primitive_poses}" />
+      <input_port name="primitives" default="{primitives}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/find_best_pick.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/find_best_pick.xml
@@ -96,12 +96,7 @@
                         element="{best_pick_primitive_name}"
                         index="{index1}"
                       />
-                      <Action
-                        ID="GetElementOfVector"
-                        vector_in="{primitives}"
-                        element="{best_pick_primitive}"
-                        index="{index1}"
-                      />
+                      <Action ID="Script" code="best_pick_primitive_index := index1" />
                       <Action
                         ID="GetElementOfVector"
                         vector_in="{surface_poses}"
@@ -144,7 +139,10 @@
   <TreeNodesModel>
     <SubTree ID="Find Best Pick">
       <output_port name="best_pick_pose" default="{best_pick_pose}" />
-      <output_port name="best_pick_primitive" default="{best_pick_primitive}" />
+      <output_port
+        name="best_pick_primitive_index"
+        default="{best_pick_primitive_index}"
+      />
       <output_port
         name="best_pick_primitive_name"
         default="{best_pick_primitive_name}"

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/generate_bin_objects.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/generate_bin_objects.xml
@@ -54,7 +54,7 @@
           <SubTree
             ID="AddToVector"
             _collapsed="true"
-            element="1.0;0.0;0.0"
+            element="1.0;0.5;0.0"
             input_vector="{positions}"
             output_vector="{positions}"
           />
@@ -68,7 +68,7 @@
           <SubTree
             ID="AddToVector"
             _collapsed="true"
-            element="1.0;0.0;0.0"
+            element="1.0;-0.5;0.0"
             input_vector="{positions}"
             output_vector="{positions}"
           />
@@ -123,6 +123,7 @@
         </Control>
       </Control>
       <Action ID="ResetVector" vector="{primitives}" />
+      <Action ID="ResetVector" vector="{primitive_poses}" />
       <Decorator
         ID="ForEach"
         out="{primitive_name}"
@@ -170,6 +171,13 @@
             input_vector="{primitives}"
             output_vector="{primitives}"
           />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="{pose}"
+            input_vector="{primitive_poses}"
+            output_vector="{primitive_poses}"
+          />
           <Control ID="Sequence" name="publish a marker">
             <Action ID="ResetVector" vector="{poses}" />
             <SubTree
@@ -195,6 +203,7 @@
     <SubTree ID="Generate Bin Objects">
       <output_port name="primitive_names" default="{primitive_names}" />
       <output_port name="primitives" default="{primitives}" />
+      <output_port name="primitive_poses" default="{primitive_poses}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/generate_bin_objects.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/generate_bin_objects.xml
@@ -2,126 +2,14 @@
 <root BTCPP_format="4" main_tree_to_execute="Generate Bin Objects">
   <BehaviorTree ID="Generate Bin Objects" _description="" _favorite="false">
     <Control ID="Sequence" name="TopLevelSequence">
-      <Control ID="Sequence" name="hardcode primitive data here in vectors">
-        <Action ID="ResetVector" vector="{primitive_names}" />
-        <SubTree
-          ID="AddToVector"
-          _collapsed="true"
-          input_vector="{primitive_names}"
-          output_vector="{primitive_names}"
-          element="cube1"
-        />
-        <SubTree
-          ID="AddToVector"
-          _collapsed="true"
-          input_vector="{primitive_names}"
-          output_vector="{primitive_names}"
-          element="sphere1"
-        />
-        <SubTree
-          ID="AddToVector"
-          _collapsed="true"
-          input_vector="{primitive_names}"
-          output_vector="{primitive_names}"
-          element="cylinder1"
-        />
-        <Control ID="Sequence" name="dims for each">
-          <Action ID="ResetVector" vector="{dimensions}" />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="0.1;0.1;0.1"
-            input_vector="{dimensions}"
-            output_vector="{dimensions}"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="0.1;0.1;0.1"
-            input_vector="{dimensions}"
-            output_vector="{dimensions}"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="0.1;0.1;0.1"
-            input_vector="{dimensions}"
-            output_vector="{dimensions}"
-          />
-        </Control>
-        <Control ID="Sequence" name="positions for each">
-          <Action ID="ResetVector" vector="{positions}" />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="1.0;0.5;0.0"
-            input_vector="{positions}"
-            output_vector="{positions}"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="1.0;0.0;0.0"
-            input_vector="{positions}"
-            output_vector="{positions}"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="1.0;-0.5;0.0"
-            input_vector="{positions}"
-            output_vector="{positions}"
-          />
-        </Control>
-        <Control ID="Sequence" name="orientations for each">
-          <Action ID="ResetVector" vector="{orientations}" />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="0.0;0.0;0.0;1.0"
-            input_vector="{orientations}"
-            output_vector="{orientations}"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="0.0;0.0;0.0;1.0"
-            input_vector="{orientations}"
-            output_vector="{orientations}"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            element="0.0;0.0;0.0;1.0"
-            input_vector="{orientations}"
-            output_vector="{orientations}"
-          />
-        </Control>
-        <Control ID="Sequence" name="type for each">
-          <Action ID="ResetVector" vector="{types}" />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            input_vector="{types}"
-            output_vector="{types}"
-            element="cube"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            input_vector="{types}"
-            output_vector="{types}"
-            element="sphere"
-          />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="true"
-            input_vector="{types}"
-            output_vector="{types}"
-            element="cylinder"
-          />
-        </Control>
-      </Control>
+      <Action
+        ID="ReadYamlList"
+        package_name="picknik_009_ur5e_config_mock_hw"
+        relative_file_path="config/bin_layouts.yaml"
+        key1="{bin_layout_name}"
+        key2="primitive_names"
+        value_list="{primitive_names}"
+      />
       <Action ID="ResetVector" vector="{primitives}" />
       <Action ID="ResetVector" vector="{primitive_poses}" />
       <Decorator
@@ -131,14 +19,22 @@
       >
         <Control ID="Sequence">
           <Action
-            ID="GetElementOfVector"
-            element="{orient}"
-            vector_in="{orientations}"
+            ID="ReadYamlValue"
+            package_name="picknik_009_ur5e_config_mock_hw"
+            relative_file_path="config/bin_layouts.yaml"
+            key1="{bin_layout_name}"
+            key2="{primitive_name}"
+            key3="orientation"
+            value="{orient}"
           />
           <Action
-            ID="GetElementOfVector"
-            element="{pos}"
-            vector_in="{positions}"
+            ID="ReadYamlValue"
+            package_name="picknik_009_ur5e_config_mock_hw"
+            relative_file_path="config/bin_layouts.yaml"
+            key1="{bin_layout_name}"
+            key2="{primitive_name}"
+            key3="position"
+            value="{pos}"
           />
           <Action
             ID="CreateStampedPose"
@@ -147,15 +43,22 @@
             stamped_pose="{pose}"
           />
           <Action
-            ID="GetElementOfVector"
-            element="{type}"
-            vector_in="{types}"
+            ID="ReadYamlValue"
+            package_name="picknik_009_ur5e_config_mock_hw"
+            relative_file_path="config/bin_layouts.yaml"
+            key1="{bin_layout_name}"
+            key2="{primitive_name}"
+            key3="type"
+            value="{type}"
           />
           <Action
-            ID="GetElementOfVector"
-            element="{dims}"
-            vector_in="{dimensions}"
-            index="{index}"
+            ID="ReadYamlValue"
+            package_name="picknik_009_ur5e_config_mock_hw"
+            relative_file_path="config/bin_layouts.yaml"
+            key1="{bin_layout_name}"
+            key2="{primitive_name}"
+            key3="dimensions"
+            value="{dims}"
           />
           <Action
             ID="CreateSolidPrimitiveFromShape"
@@ -201,6 +104,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Generate Bin Objects">
+      <input_port name="bin_layout_name" default="layout_1" />
       <output_port name="primitive_names" default="{primitive_names}" />
       <output_port name="primitives" default="{primitives}" />
       <output_port name="primitive_poses" default="{primitive_poses}" />

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/generate_bin_objects.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/generate_bin_objects.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Generate Bin Objects">
+  <BehaviorTree ID="Generate Bin Objects" _description="" _favorite="false">
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Control ID="Sequence" name="hardcode primitive data here in vectors">
+        <Action ID="ResetVector" vector="{primitive_names}" />
+        <SubTree
+          ID="AddToVector"
+          _collapsed="true"
+          input_vector="{primitive_names}"
+          output_vector="{primitive_names}"
+          element="cube1"
+        />
+        <SubTree
+          ID="AddToVector"
+          _collapsed="true"
+          input_vector="{primitive_names}"
+          output_vector="{primitive_names}"
+          element="sphere1"
+        />
+        <SubTree
+          ID="AddToVector"
+          _collapsed="true"
+          input_vector="{primitive_names}"
+          output_vector="{primitive_names}"
+          element="cylinder1"
+        />
+        <Control ID="Sequence" name="dims for each">
+          <Action ID="ResetVector" vector="{dimensions}" />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="0.1;0.1;0.1"
+            input_vector="{dimensions}"
+            output_vector="{dimensions}"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="0.1;0.1;0.1"
+            input_vector="{dimensions}"
+            output_vector="{dimensions}"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="0.1;0.1;0.1"
+            input_vector="{dimensions}"
+            output_vector="{dimensions}"
+          />
+        </Control>
+        <Control ID="Sequence" name="positions for each">
+          <Action ID="ResetVector" vector="{positions}" />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="1.0;0.0;0.0"
+            input_vector="{positions}"
+            output_vector="{positions}"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="1.0;0.0;0.0"
+            input_vector="{positions}"
+            output_vector="{positions}"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="1.0;0.0;0.0"
+            input_vector="{positions}"
+            output_vector="{positions}"
+          />
+        </Control>
+        <Control ID="Sequence" name="orientations for each">
+          <Action ID="ResetVector" vector="{orientations}" />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="0.0;0.0;0.0;1.0"
+            input_vector="{orientations}"
+            output_vector="{orientations}"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="0.0;0.0;0.0;1.0"
+            input_vector="{orientations}"
+            output_vector="{orientations}"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="0.0;0.0;0.0;1.0"
+            input_vector="{orientations}"
+            output_vector="{orientations}"
+          />
+        </Control>
+        <Control ID="Sequence" name="type for each">
+          <Action ID="ResetVector" vector="{types}" />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            input_vector="{types}"
+            output_vector="{types}"
+            element="cube"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            input_vector="{types}"
+            output_vector="{types}"
+            element="sphere"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            input_vector="{types}"
+            output_vector="{types}"
+            element="cylinder"
+          />
+        </Control>
+      </Control>
+      <Action ID="ResetVector" vector="{primitives}" />
+      <Decorator
+        ID="ForEach"
+        out="{primitive_name}"
+        vector_in="{primitive_names}"
+      >
+        <Control ID="Sequence">
+          <Action
+            ID="GetElementOfVector"
+            element="{orient}"
+            vector_in="{orientations}"
+          />
+          <Action
+            ID="GetElementOfVector"
+            element="{pos}"
+            vector_in="{positions}"
+          />
+          <Action
+            ID="CreateStampedPose"
+            position_xyz="{pos}"
+            orientation_xyzw="{orient}"
+            stamped_pose="{pose}"
+          />
+          <Action
+            ID="GetElementOfVector"
+            element="{type}"
+            vector_in="{types}"
+          />
+          <Action
+            ID="GetElementOfVector"
+            element="{dims}"
+            vector_in="{dimensions}"
+            index="{index}"
+          />
+          <Action
+            ID="CreateSolidPrimitiveFromShape"
+            pose_stamped="{pose}"
+            shape_type="{type}"
+            solid_primitive="{primitive}"
+            dimensions="{dims}"
+          />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="{primitive}"
+            input_vector="{primitives}"
+            output_vector="{primitives}"
+          />
+          <Control ID="Sequence" name="publish a marker">
+            <Action ID="ResetVector" vector="{poses}" />
+            <SubTree
+              ID="AddToVector"
+              _collapsed="true"
+              input_vector="{poses}"
+              element="{pose}"
+              output_vector="{poses}"
+            />
+            <Action
+              ID="PublishMarkers"
+              marker_poses="{poses}"
+              marker_namespace="{primitive_name}"
+              marker_scale_xyz="{dims}"
+              marker_type="{type}"
+            />
+          </Control>
+        </Control>
+      </Decorator>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Generate Bin Objects">
+      <output_port name="primitive_names" default="{primitive_names}" />
+      <output_port name="primitives" default="{primitives}" />
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/test_find_best_pick.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/test_find_best_pick.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Test Find Best Pick">
+  <BehaviorTree ID="Test Find Best Pick" _description="" _favorite="false">
+    <Control ID="Sequence" name="TopLevelSequence">
+      <SubTree
+        ID="Generate Bin Objects"
+        _collapsed="true"
+        primitive_names="{primitive_names}"
+      />
+      <SubTree ID="Find Best Pick" _collapsed="true" />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Test Find Best Pick" />
+  </TreeNodesModel>
+</root>

--- a/src/picknik_009_ur5e_config_mock_hw/objectives/test_find_best_pick.xml
+++ b/src/picknik_009_ur5e_config_mock_hw/objectives/test_find_best_pick.xml
@@ -2,11 +2,7 @@
 <root BTCPP_format="4" main_tree_to_execute="Test Find Best Pick">
   <BehaviorTree ID="Test Find Best Pick" _description="" _favorite="false">
     <Control ID="Sequence" name="TopLevelSequence">
-      <SubTree
-        ID="Generate Bin Objects"
-        _collapsed="true"
-        primitive_names="{primitive_names}"
-      />
+      <SubTree ID="Generate Bin Objects" _collapsed="true" />
       <SubTree ID="Find Best Pick" _collapsed="true" />
     </Control>
   </BehaviorTree>


### PR DESCRIPTION
Adds the `Find Best Pick` Objective that takes in Solid primitives and their poses and outputs the index of the primitive that is most optimal.

Algorithm:
1. Using basic surface centroid geometry find candidate poses on the surfaces of the primitives. For curved surfaces sample about a centroidal axis with a fixed resolution.
2. Solve all poses for IK (also takes the planning scene into account)
3. From the solved poses, find the highest one. The primitive it belongs to is the best pick.

Also Adds a `Generate Bin Objects` objective to read primitives from yaml to speed up testing multiple scenarios.

To Run, use the objective: `Test Find Best Pick`.

Missing: Stateful Decisions, i.e. will not take into account the last primitive that was picked to select a primitive from a disparate zone.