### PR TITLE
chore: align Dockerfile with canonical workspace template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@
 #
 
 # Specify the MoveIt Pro release to build on top of.
-ARG MOVEIT_PRO_BASE_IMAGE=picknikciuser/moveit-pro:${MOVEIT_DOCKER_TAG:-main}-${MOVEIT_ROS_DISTRO:-humble}
-ARG USERNAME=studio-user
+ARG MOVEIT_PRO_BASE_IMAGE=picknikciuser/moveit-studio:${MOVEIT_DOCKER_TAG:-main}-${MOVEIT_ROS_DISTRO:-humble}
+ARG USERNAME=moveit-pro-user
 ARG USER_UID=1000
 ARG USER_GID=1000
 
@@ -26,10 +26,6 @@ ARG USER_GID
 # Copy source code from the workspace's ROS 2 packages to a workspace inside the container
 ARG USER_WS=/home/${USERNAME}/user_ws
 ENV USER_WS=${USER_WS}
-
-# Set real time limits
-# Ensure the directory exists
-RUN mkdir -p /etc/security
 
 # Also mkdir with user permission directories which will be mounted later to avoid docker creating them as root
 WORKDIR $USER_WS
@@ -65,7 +61,7 @@ RUN groupadd realtime && \
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=bind,target=${USER_WS}/,source=. \
+    --mount=type=bind,target=${USER_WS}/src,source=./src \
     . /opt/overlay_ws/install/setup.sh && \
     apt-get update && \
     rosdep install -q -y \
@@ -103,138 +99,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         less \
         gdb \
         nano \
-	tmux
+        tmux
 
 # Set up the user's .bashrc file and shell.
 CMD ["/usr/bin/bash"]
-
-
-##################################################
-# Starting from the specified MoveIt Pro release with CUDA GPU #
-##################################################
-# The image tag is specified in the argument itself.
-# hadolint ignore=DL3006
-FROM ${MOVEIT_PRO_BASE_IMAGE} AS base-gpu
-
-# Create a non-root user
-ARG USERNAME
-ARG USER_UID
-ARG USER_GID
-
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install wget -y -q --no-install-recommends && \
-    wget --progress=dot:giga https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb && \
-    dpkg -i cuda-keyring_1.1-1_all.deb && \
-    apt-get update && \
-    apt-get install -q -y --no-install-recommends \
-      libcudnn9-cuda-12 \
-      libcudnn9-dev-cuda-12 \
-      libcublas-12-6 \
-      cuda-cudart-12-6 \
-      libcurand-12-6 \
-      libcufft-12-6 \
-      libnvinfer10 \
-      libnvinfer-plugin10 \
-      libnvonnxparsers10 \
-      libtree
-
-# Misleading name: onnxruntime_gpu is actually specifically the CUDA package. This is only shipped for x86-64
-RUN if [ "$(uname -m)" = "x86_64" ]; then pip3 install --no-cache-dir onnxruntime_gpu==1.19.0; fi
-
-# Copy source code from the workspace's ROS 2 packages to a workspace inside the container
-ARG USER_WS=/home/${USERNAME}/user_ws
-ENV USER_WS=${USER_WS}
-
-# Also mkdir with user permission directories which will be mounted later to avoid docker creating them as root
-WORKDIR $USER_WS
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    groupadd --gid $USER_GID ${USERNAME} && \
-    useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash --create-home ${USERNAME} && \
-    apt-get update && \
-    apt-get install -q -y --no-install-recommends sudo && \
-    echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME} && \
-    chmod 0440 /etc/sudoers.d/${USERNAME} && \
-    cp -r /etc/skel/. /home/${USERNAME} && \
-    mkdir -p \
-      /home/${USERNAME}/.ccache \
-      /home/${USERNAME}/.config \
-      /home/${USERNAME}/.ignition \
-      /home/${USERNAME}/.colcon \
-      /home/${USERNAME}/.ros && \
-    chown -R $USER_UID:$USER_GID /home/${USERNAME} /opt/overlay_ws/
-
-# Install additional dependencies
-# You can also add any necessary apt-get install, pip install, etc. commands at this point.
-# NOTE: The /opt/overlay_ws folder contains MoveIt Pro binary packages and the source file.
-# hadolint ignore=SC1091
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=bind,target=${USER_WS}/,source=. \
-    . /opt/overlay_ws/install/setup.sh && \
-    apt-get update && \
-    rosdep install -q -y \
-      --from-paths src \
-      --ignore-src
-
-# Set up colcon defaults for the new user
-USER ${USERNAME}
-RUN colcon mixin add default \
-    https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
-    colcon mixin update && \
-    colcon metadata add default \
-    https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
-    colcon metadata update
-COPY colcon-defaults.yaml /home/${USERNAME}/.colcon/defaults.yaml
-
-# hadolint ignore=DL3002
-USER root
-
-# Set up the user's .bashrc file and shell.
-CMD ["/usr/bin/bash"]
-
-###################################################################
-# Target for the developer build which does not compile any code. #
-###################################################################
-FROM base-gpu  AS user-overlay-gpu-dev
-
-ARG USERNAME
-ARG USER_WS=/home/${USERNAME}/user_ws
-ENV USER_WS=${USER_WS}
-
-# Install any additional packages for development work
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        less \
-        gdb \
-        nano
-
-# Set up the user's .bashrc file and shell.
-CMD ["/usr/bin/bash"]
-
-#########################################
-# Target for compiled, deployable image with GPU support #
-#########################################
-FROM base-gpu AS user-overlay-gpu
-
-ARG USERNAME
-ARG USER_WS=/home/${USERNAME}/user_ws
-ENV USER_WS=${USER_WS}
-
-ENV LD_LIBRARY_PATH=/usr/local/lib/python3.10/dist-packages/onnxruntime/capi:/usr/lib/x86_64-linux-gnu:/usr/local/cuda-12.6/targets/x86_64-linux/lib:$LD_LIBRARY_PATH
-
-# Compile the workspace
-WORKDIR $USER_WS
-
-# Set up the user's .bashrc file and shell.
-CMD ["/usr/bin/bash"]
-
 
 #########################################
 # Target for compiled, deployable image #


### PR DESCRIPTION
This Dockerfile had drifted out of sync with the rest of the example workspace repos.

1. Drop the base-gpu / user-overlay-gpu-dev / user-overlay-gpu stages. These are duplicative in MoveIt Pro 9.

2. Change MOVEIT_PRO_BASE_IMAGE default from picknikciuser/moveit-pro to picknikciuser/moveit-studio.

3. Change USERNAME default from studio-user to moveit-pro-user.

Other small cleanups while in here:
- Drop the 'mkdir -p /etc/security' block; the Pro base image already prepares RT limits and the realtime group.
- Tighten the rosdep bind mount from the whole workspace to just src/. rosdep install --from-paths src only ever needs src/.
- Replace tab indent with spaces on the tmux line.

After this change the Dockerfile is byte-identical to the canonical template (moveit_pro_example_ws / moveit_pro_fanuc_ws / etc.).